### PR TITLE
ColSpec

### DIFF
--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -211,6 +211,7 @@ end
 # IMPLEMENTATIONS
 # ----------------
 
+include("transforms/colspec.jl")
 include("transforms/select.jl")
 include("transforms/filter.jl")
 include("transforms/rename.jl")

--- a/src/transforms/colspec.jl
+++ b/src/transforms/colspec.jl
@@ -5,7 +5,7 @@
 # types used to select a column
 const ColSelector = Union{Symbol, Integer, AbstractString}
 # types used to filter columns
-const ColSpec = Union{Vector{T}, NTuple{N,T}, Regex, Colon} where {N,T<:ColSelector}
+# const ColSpec = Union{Vector{T}, NTuple{N,T}, Regex, Colon} where {N,T<:ColSelector}
 
 # filter table columns using colspec
 function _filter(colspec::Vector{Symbol}, cols)

--- a/src/transforms/colspec.jl
+++ b/src/transforms/colspec.jl
@@ -3,9 +3,7 @@
 # ------------------------------------------------------------------
 
 # types used to select a column
-const ColSelector = Union{Symbol, Integer, AbstractString}
-# types used to filter columns
-# const ColSpec = Union{Vector{T}, NTuple{N,T}, Regex, Colon} where {N,T<:ColSelector}
+const ColSelector = Union{Symbol,Integer,AbstractString}
 
 # filter table columns using colspec
 function _filter(colspec::Vector{Symbol}, cols)

--- a/src/transforms/colspec.jl
+++ b/src/transforms/colspec.jl
@@ -1,0 +1,39 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+# types used to select a column
+const ColSelector = Union{Symbol, Integer, AbstractString}
+# types used to filter columns
+const ColSpec = Union{Vector{T}, NTuple{N,T}, Regex, Colon} where {N,T<:ColSelector}
+
+# filter table columns using colspec
+function _filter(colspec::Vector{Symbol}, cols)
+  # validate columns
+  @assert !isempty(colspec) "Invalid column selection."
+  @assert colspec ⊆ cols "Invalid column selection."
+  return colspec
+end
+
+_filter(colspec::Vector{<:AbstractString}, cols) = 
+  _filter(Symbol.(colspec), cols)
+
+_filter(colspec::Vector{<:Integer}, cols::Vector) = 
+  _filter(cols[colspec], cols)
+
+_filter(colspec::Vector{<:Integer}, cols::Tuple) = 
+  _filter(colspec, collect(cols))
+
+_filter(colspec::NTuple{N,<:ColSelector}, cols) where {N} =
+  _filter(collect(colspec), cols)
+
+function _filter(colspec::Regex, cols::Vector)
+  fcols = filter(col -> occursin(colspec, String(col)), cols)
+  _filter(fcols, cols)
+end
+
+_filter(colspec::Regex, cols::Tuple) = 
+  _filter(colspec, collect(cols))
+
+_filter(::Colon, cols::Vector) = cols
+_filter(::Colon, cols::Tuple) = collect(cols)

--- a/src/transforms/filter.jl
+++ b/src/transforms/filter.jl
@@ -39,7 +39,6 @@ end
 # DropMissing
 
 const VecOrTuple{T} = Union{Vector{T}, NTuple{N, T}} where {T, N}
-const ColSelector = Union{Symbol, Integer, AbstractString}
 
 """
     DropMissing()

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1,7 +1,7 @@
 @testset "Transforms" begin
   # using MersenneTwister for compatibility between Julia versions
   rng = MersenneTwister(42)
-  @testset "colspec" begin
+  @testset "ColSpec" begin
     veccols = [:a, :b, :c, :d, :e, :f]
     tupcols = (:a, :b, :c, :d, :e, :f)
     

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1,6 +1,74 @@
 @testset "Transforms" begin
   # using MersenneTwister for compatibility between Julia versions
   rng = MersenneTwister(42)
+  @testset "colspec" begin
+    veccols = [:a, :b, :c, :d, :e, :f]
+    tupcols = (:a, :b, :c, :d, :e, :f)
+    
+    # vector of symbols
+    colspec = [:a, :c, :e]
+    cols = TableTransforms._filter(colspec, veccols)
+    @test cols == [:a, :c, :e]
+    cols = TableTransforms._filter(colspec, tupcols)
+    @test cols == [:a, :c, :e]
+
+    # tuple of symbols
+    colspec = (:a, :c, :e)
+    cols = TableTransforms._filter(colspec, veccols)
+    @test cols == [:a, :c, :e]
+    cols = TableTransforms._filter(colspec, tupcols)
+    @test cols == [:a, :c, :e]
+
+    # vector of strings
+    colspec = ["a", "c", "e"]
+    cols = TableTransforms._filter(colspec, veccols)
+    @test cols == [:a, :c, :e]
+    cols = TableTransforms._filter(colspec, tupcols)
+    @test cols == [:a, :c, :e]
+
+    # tuple of strings
+    colspec = ("a", "c", "e")
+    cols = TableTransforms._filter(colspec, veccols)
+    @test cols == [:a, :c, :e]
+    cols = TableTransforms._filter(colspec, tupcols)
+    @test cols == [:a, :c, :e]
+
+    # vector of integers
+    colspec = [1, 3, 5]
+    cols = TableTransforms._filter(colspec, veccols)
+    @test cols == [:a, :c, :e]
+    cols = TableTransforms._filter(colspec, tupcols)
+    @test cols == [:a, :c, :e]
+
+    # tuple of integers
+    colspec = (1, 3, 5)
+    cols = TableTransforms._filter(colspec, veccols)
+    @test cols == [:a, :c, :e]
+    cols = TableTransforms._filter(colspec, tupcols)
+    @test cols == [:a, :c, :e]
+
+    # regex
+    colspec = r"[ace]"
+    cols = TableTransforms._filter(colspec, veccols)
+    @test cols == [:a, :c, :e]
+    cols = TableTransforms._filter(colspec, tupcols)
+    @test cols == [:a, :c, :e]
+
+    # colon
+    cols = TableTransforms._filter(:, veccols)
+    @test cols == [:a, :b, :c, :d, :e, :f]
+    cols = TableTransforms._filter(:, tupcols)
+    @test cols == [:a, :b, :c, :d, :e, :f]
+
+    # throws
+    @test_throws AssertionError TableTransforms._filter(r"x", veccols)
+    @test_throws AssertionError TableTransforms._filter(r"x", tupcols)
+    @test_throws AssertionError TableTransforms._filter(String[], veccols)
+    @test_throws AssertionError TableTransforms._filter(String[], tupcols)
+    @test_throws AssertionError TableTransforms._filter(Symbol[], veccols)
+    @test_throws AssertionError TableTransforms._filter(Symbol[], tupcols)
+  end
+
   @testset "Select" begin
     a = rand(4000)
     b = rand(4000)

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -67,6 +67,24 @@
     @test_throws AssertionError TableTransforms._filter(String[], tupcols)
     @test_throws AssertionError TableTransforms._filter(Symbol[], veccols)
     @test_throws AssertionError TableTransforms._filter(Symbol[], tupcols)
+
+    # type stability
+    @inferred TableTransforms._filter([:a, :b], veccols)
+    @inferred TableTransforms._filter([:a, :b], tupcols)
+    @inferred TableTransforms._filter((:a, :b), veccols)
+    @inferred TableTransforms._filter((:a, :b), tupcols)
+    @inferred TableTransforms._filter(["a", "b"], veccols)
+    @inferred TableTransforms._filter(["a", "b"], tupcols)
+    @inferred TableTransforms._filter(("a", "b"), veccols)
+    @inferred TableTransforms._filter(("a", "b"), tupcols)
+    @inferred TableTransforms._filter([1, 2], veccols)
+    @inferred TableTransforms._filter([1, 2], tupcols)
+    @inferred TableTransforms._filter((1, 2), veccols)
+    @inferred TableTransforms._filter((1, 2), tupcols)
+    @inferred TableTransforms._filter(r"[ab]", veccols)
+    @inferred TableTransforms._filter(r"[ab]", tupcols)
+    @inferred TableTransforms._filter(:, veccols)
+    @inferred TableTransforms._filter(:, tupcols)
   end
 
   @testset "Select" begin


### PR DESCRIPTION
This PR makes the ColSpec interface more generic so it can be used in all transformations that use column selections.