### PR TITLE
Support skipping missing values for certain transforms

### DIFF
--- a/src/assertions.jl
+++ b/src/assertions.jl
@@ -9,6 +9,9 @@ function assert_continuous(table)
 end
 
 function assert_continuous_or_missing(table)
-  types = schema(table).scitypes
-  @assert all(T <: Union{Missing, Continuous} for T in types) "columns must hold continuous variables"
+  cols = Tables.columns(table)
+  for col in cols
+      type = scitype(col)
+      @assert type <: AbstractVector{<:Union{Missing, Continuous}} "columns must hold continuous variables"
+  end
 end

--- a/src/assertions.jl
+++ b/src/assertions.jl
@@ -7,3 +7,8 @@ function assert_continuous(table)
   types = schema(table).scitypes
   @assert all(T <: Continuous for T in types) "columns must hold continuous variables"
 end
+
+function assert_continuous_or_missing(table)
+  types = schema(table).scitypes
+  @assert all(T <: Union{Missing, Continuous} for T in types) "columns must hold continuous variables"
+end

--- a/src/transforms/center.jl
+++ b/src/transforms/center.jl
@@ -3,17 +3,28 @@
 # ------------------------------------------------------------------
 
 """
-    Center()
+    Center(skipmissing=true)
 
-The transform that removes the mean of the variables.
+The transform that removes the mean of the variables. Skips the missing values by default.
 """
-struct Center <: Colwise end
 
-assertions(::Type{Center}) = [assert_continuous]
+struct Center <: Colwise
+    skipmissing::Bool
+end
+
+Center(;skipmissing=true) = Center(skipmissing)
+
+assertions(::Type{Center}) = [assert_continuous_or_missing]
 
 isrevertible(::Type{Center}) = true
 
-colcache(::Center, x) = mean(x)
+function colcache(transform::Center, x)
+    if transform.skipmissing
+        mean(skipmissing(x))
+    else
+        mean(x)
+    end
+end
 
 colapply(::Center, x, μ)  = @. x - μ
 


### PR DESCRIPTION
- Add `assert_continuous_or_missing` function which replaces `assert_continuous` in transforms that are going to support skipping missing values.
- Revise those transforms to support skipping missing values. Makes this an argument that defaults to true.
  
Opened this PR to give better idea about what I have in mind. Still working on tests.