### PR TITLE
Avoid `Union{Missing,T}` in columns after DropMissing

### DIFF
--- a/src/transforms/filter.jl
+++ b/src/transforms/filter.jl
@@ -73,21 +73,19 @@ _ftrans(::DropMissing, cols) =
   Filter(row -> all(!ismissing, getindex.(Ref(row), cols)))
 
 # nonmissing 
-_nonmissing(::Type{T}, c) where {T} = c
-_nonmissing(::Type{Union{Missing,T}}, c) where {T} =
-  collect(T, c)
-
-_nonmissing(col) = _nonmissing(eltype(col), col)
+_nonmissing(::Type{T}, x) where {T} = x
+_nonmissing(::Type{Union{Missing,T}}, x) where {T} = collect(T, x)
+_nonmissing(x) = _nonmissing(eltype(x), x)
 
 function apply(transform::DropMissing, table)
   colnames = Tables.columnnames(table)
-  select = _filter(transform.colspec, colnames)
-  ftrans = _ftrans(transform, select)
+  selnames = _filter(transform.colspec, colnames)
+  ftrans = _ftrans(transform, selnames)
   newtable, fcache = apply(ftrans, table)
 
   # post-processing
   coltable = Tables.columntable(newtable)
-  pcolumns = [nm ∈ select ? _nonmissing(col) : col for (nm, col) in pairs(coltable)]
+  pcolumns = [nm ∈ selnames ? _nonmissing(x) : x for (nm, x) in pairs(coltable)]
   𝒯 = (; zip(colnames, pcolumns)...)
   ptable = 𝒯 |> Tables.materializer(newtable)
 
@@ -101,7 +99,7 @@ function revert(::DropMissing, newtable, cache)
   # pre-processing
   colnames = Tables.columnnames(newtable)
   coltable = Tables.columntable(newtable)
-  pcolumns = [collect(T, col) for (T, col) in zip(types, coltable)]
+  pcolumns = [collect(T, x) for (T, x) in zip(types, coltable)]
   𝒯 = (; zip(colnames, pcolumns)...)
   ptable = 𝒯 |> Tables.materializer(newtable)
 

--- a/src/transforms/filter.jl
+++ b/src/transforms/filter.jl
@@ -65,15 +65,21 @@ DropMissing(cols::T...) where {T<:ColSelector} =
 
 isrevertible(::Type{<:DropMissing}) = true
 
+# ftrans
 _ftrans(::DropMissing{Colon}, cols) =
   Filter(row -> all(!ismissing, row))
 
 _ftrans(::DropMissing, cols) =
   Filter(row -> all(!ismissing, getindex.(Ref(row), cols)))
 
+# nonmissing 
+_nonmissing(::Type{T}, c) where {T} = c
+_nonmissing(::Type{Union{Missing,T}}, c) where {T} =
+  collect(T, c)
+
 function _nonmissing(columns, col)
   c = Tables.getcolumn(columns, col)
-  collect(nonmissingtype(eltype(c)), c)
+  _nonmissing(eltype(c), c)
 end
 
 function _nonmissing(table, cols, allcols)
@@ -84,6 +90,7 @@ function _nonmissing(table, cols, allcols)
   𝒯 |> Tables.materializer(table)
 end
 
+# reverttypes
 function _reverttypes(table, types)
   columns = Tables.columns(table)
   allcols = Tables.columnnames(table)

--- a/src/transforms/filter.jl
+++ b/src/transforms/filter.jl
@@ -78,30 +78,30 @@ _nonmissing(x) = _nonmissing(eltype(x), x)
 
 function apply(transform::DropMissing, table)
   names = Tables.columnnames(table)
-  coltypes = Tables.schema(table).types
-  selnames = _filter(transform.colspec, names)
-  ftrans = _ftrans(transform, selnames)
+  types = Tables.schema(table).types
+  snames = _filter(transform.colspec, names)
+  ftrans = _ftrans(transform, snames)
   newtable, fcache = apply(ftrans, table)
 
   # post-processing
   cols = Tables.columns(newtable)
   pcols = map(names) do n
     x = Tables.getcolumn(cols, n)
-    n ∈ selnames ? _nonmissing(x) : x
+    n ∈ snames ? _nonmissing(x) : x
   end
   𝒯 = (; zip(names, pcols)...)
   ptable = 𝒯 |> Tables.materializer(newtable)
 
-  ptable, (ftrans, fcache, coltypes)
+  ptable, (ftrans, fcache, types)
 end
 
 function revert(::DropMissing, newtable, cache)
-  ftrans, fcache, coltypes = cache
+  ftrans, fcache, types = cache
 
   # pre-processing
   cols = Tables.columns(newtable)
   names = Tables.columnnames(newtable)
-  pcols = map(zip(coltypes, names)) do (T, n)
+  pcols = map(zip(types, names)) do (T, n)
     x = Tables.getcolumn(cols, n)
     collect(T, x)
   end

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -598,6 +598,45 @@
     @test isequalmissing(n.e, [missing, 5, 6, 5])
     @test isequalmissing(n.f, [4, missing, 4, 5])
 
+    # column eltype
+    ttypes = Tables.schema(t).types
+
+    T = DropMissing()
+    n, c = apply(T, t)
+    ntypes = Tables.schema(n).types
+    @test ntypes[1] == Int
+    @test ntypes[2] == Int
+    @test ntypes[3] == Int
+    @test ntypes[4] == Int
+    @test ntypes[5] == Int
+    @test ntypes[6] == Int
+    tₒ = revert(T, n, c)
+    @test ttypes == Tables.schema(tₒ).types
+
+    T = DropMissing([:a, :c, :d])
+    n, c = apply(T, t)
+    ntypes = Tables.schema(n).types
+    @test ntypes[1] == Int
+    @test ntypes[2] == Union{Missing,Int}
+    @test ntypes[3] == Int
+    @test ntypes[4] == Int
+    @test ntypes[5] == Union{Missing,Int}
+    @test ntypes[6] == Union{Missing,Int}
+    tₒ = revert(T, n, c)
+    @test ttypes == Tables.schema(tₒ).types
+
+    T = DropMissing([:b, :e, :f])
+    n, c = apply(T, t)
+    ntypes = Tables.schema(n).types
+    @test ntypes[1] == Union{Missing,Int}
+    @test ntypes[2] == Int
+    @test ntypes[3] == Union{Missing,Int}
+    @test ntypes[4] == Union{Missing,Int}
+    @test ntypes[5] == Int
+    @test ntypes[6] == Int
+    tₒ = revert(T, n, c)
+    @test ttypes == Tables.schema(tₒ).types
+
     # reapply test
     T = DropMissing()
     n1, c1 = apply(T, t)

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -598,11 +598,11 @@
     @test isequalmissing(n.e, [missing, 5, 6, 5])
     @test isequalmissing(n.f, [4, missing, 4, 5])
 
-    # column eltype
-    ttypes = Tables.schema(t).types
-
+    # table schema after apply and revert
     T = DropMissing()
     n, c = apply(T, t)
+    tₒ = revert(T, n, c)
+    ttypes = Tables.schema(t).types
     ntypes = Tables.schema(n).types
     @test ntypes[1] == Int
     @test ntypes[2] == Int
@@ -610,11 +610,11 @@
     @test ntypes[4] == Int
     @test ntypes[5] == Int
     @test ntypes[6] == Int
-    tₒ = revert(T, n, c)
     @test ttypes == Tables.schema(tₒ).types
 
     T = DropMissing([:a, :c, :d])
     n, c = apply(T, t)
+    tₒ = revert(T, n, c)
     ntypes = Tables.schema(n).types
     @test ntypes[1] == Int
     @test ntypes[2] == Union{Missing,Int}
@@ -622,11 +622,11 @@
     @test ntypes[4] == Int
     @test ntypes[5] == Union{Missing,Int}
     @test ntypes[6] == Union{Missing,Int}
-    tₒ = revert(T, n, c)
     @test ttypes == Tables.schema(tₒ).types
 
     T = DropMissing([:b, :e, :f])
     n, c = apply(T, t)
+    tₒ = revert(T, n, c)
     ntypes = Tables.schema(n).types
     @test ntypes[1] == Union{Missing,Int}
     @test ntypes[2] == Int
@@ -634,7 +634,6 @@
     @test ntypes[4] == Union{Missing,Int}
     @test ntypes[5] == Int
     @test ntypes[6] == Int
-    tₒ = revert(T, n, c)
     @test ttypes == Tables.schema(tₒ).types
 
     # reapply test


### PR DESCRIPTION
This PR adds a post-processing in the apply function of the DropMissing transformation and a pre-processing in the revert function.
This is necessary so that the type of columns where the DropMissing transformation will be applied is `T` instead of `Union{Missing,T}` .