### PR TITLE
New Functional

### DIFF
--- a/src/transforms/functional.jl
+++ b/src/transforms/functional.jl
@@ -33,16 +33,17 @@ Functional(pairs::Pair{K}...) where {K<:AbstractString} =
 Functional() = throw(ArgumentError("Cannot create a Functional object without arguments."))
 
 # known invertible functions
-inverse(::typeof(log))   = exp
-inverse(::typeof(exp))   = log
-inverse(::typeof(cos))   = acos
-inverse(::typeof(acos))  = cos
-inverse(::typeof(sin))   = asin
-inverse(::typeof(asin))  = sin
+inverse(::typeof(log))  = exp
+inverse(::typeof(exp))  = log
+inverse(::typeof(cos))  = acos
+inverse(::typeof(acos)) = cos
+inverse(::typeof(sin))  = asin
+inverse(::typeof(asin)) = sin
 inverse(::typeof(cosd))  = acosd
 inverse(::typeof(acosd)) = cosd
 inverse(::typeof(sind))  = asind
 inverse(::typeof(asind)) = sind
+inverse(::typeof(identity)) = identity
 
 # fallback to nothing
 inverse(::Any) = nothing
@@ -88,7 +89,7 @@ function revertfunc(transform::Functional{<:NamedTuple}, cols, nm)
   invfunc.(x)
 end
 
-function revert(transform::Filter, newtable, cache)
+function revert(transform::Functional, newtable, cache)
   cols = Tables.columns(newtable)
   names = Tables.columnnames(newtable)
   ocols = tcollect(revertfunc(transform, cols, nm) for nm in names)

--- a/src/transforms/functional.jl
+++ b/src/transforms/functional.jl
@@ -3,43 +3,75 @@
 # ------------------------------------------------------------------
 
 """
-    Functional(function)
+    Functional(func)
 
-The transform that applies a `function` elementwise.
+The transform that applies a `func` elementwise.
+
+    Functional(col₁ => func₁, col₂ => func₂, ..., colₙ => funcₙ)
+
+Applies in each `colᵢ` the function `funcᵢ` in the table.
 
 # Examples
 
 ```julia
 Functional(cos)
 Functional(sin)
+Functional(:a => cos, :b => sin)
+Functional("a" => cos, "b" => sin)
 ```
 """
-struct Functional{F} <: Colwise
-  func::F
+struct Functional{K,F} <: Stateless
+  pairs::Dict{K,F}
 end
 
-isrevertible(transform::Functional) =
-  !isnothing(inverse(transform.func))
+Functional(func) = Functional(Dict((:) => func))
+
+Functional(pairs::Pair{Symbol,F}...) where {F} =
+  Functional(Dict(pairs))
+
+Functional(pairs::Pair{K,F}...) where {K<:AbstractString,F} =
+  Functional(Dict(Symbol(k) => v for (k, v) in pairs))
+
+Functional() = throw(ArgumentError("Cannot create a Functional object without arguments."))
 
 # known invertible functions
-inverse(::typeof(log))  = exp
-inverse(::typeof(exp))  = log
-inverse(::typeof(cos))  = acos
-inverse(::typeof(acos)) = cos
-inverse(::typeof(sin))  = asin
-inverse(::typeof(asin)) = sin
+inverse(::typeof(log))   = exp
+inverse(::typeof(exp))   = log
+inverse(::typeof(cos))   = acos
+inverse(::typeof(acos))  = cos
+inverse(::typeof(sin))   = asin
+inverse(::typeof(asin))  = sin
+inverse(::typeof(cosd))  = acosd
+inverse(::typeof(acosd)) = cosd
+inverse(::typeof(sind))  = asind
+inverse(::typeof(asind)) = sind
 
 # fallback to nothing
 inverse(::Any) = nothing
 
-colcache(::Functional, x) = nothing
+isrevertible(transform::Functional{Colon}) =
+  !isnothing(inverse(transform.pairs[:]))
 
-function colapply(transform::Functional, x, c)
-  f = transform.func
-  f.(x)
+isrevertible(transform::Functional) =
+  any(isnothing, inverse.(values(transform.pairs)))
+
+function applyfunc(transform::Functional, cols, nm)
+  x = Tables.getcolumn(cols, nm)
+  func = get(transform.pairs, nm, identity)
+  func.(x)
 end
 
-function colrevert(transform::Functional, y, c)
-  g = inverse(transform.func)
-  g.(y)
+function applyfunc(transform::Functional{Colon}, cols, nm)
+  x = Tables.getcolumn(cols, nm)
+  func = transform.pairs[:]
+  func.(x)
+end
+
+function apply(transform::Functional, table) 
+  cols = Tables.getcolumns(table)
+  names = Tables.columnnames(table)
+  ncols = tcollect(applyfunc(transform, cols, nm) for nm in names)
+  𝒯 = (; zip(names, ncols)...)
+  newtable = 𝒯 |> Tables.materializer(table)
+  return newtable, nothing
 end

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -966,6 +966,43 @@
     @test all(≥(1), n.x)
     @test all(≥(1), n.y)
     @test isrevertible(T) == false
+
+    # apply functions to specific columns
+    x = π*rand(1500)
+    y = π*(rand(1500) .- 0.5)
+    z = x + y
+    t = Table(; x, y, z)
+    T = Functional(:x => cos, :y => sin)
+    n, c = apply(T, t)
+    @test all(x -> -1 ≤ x ≤ 1, n.x)
+    @test all(y -> -1 ≤ y ≤ 1, n.y)
+    @test t.z == n.z
+    tₒ = revert(T, n, c)
+    @test Tables.matrix(t) ≈ Tables.matrix(tₒ)
+
+    x = 2*(rand(1500) .- 0.5)
+    y = 2*(rand(1500) .- 0.5)
+    z = x + y
+    t = Table(; x, y, z)
+    T = Functional("x" => acos, "y" => asin)
+    n, c = apply(T, t)
+    @test all(x -> 0 ≤ x ≤ π, n.x)
+    @test all(y -> -π/2 ≤ y ≤ π/2, n.y)
+    @test t.z == n.z
+    tₒ = revert(T, n, c)
+    @test Tables.matrix(t) ≈ Tables.matrix(tₒ)
+
+    T = Functional(:x => cos, :y => sin)
+    @test isrevertible(T) == true
+    T = Functional("x" => cos, "y" => sin)
+    @test isrevertible(T) == true
+    T = Functional(:x => abs, :y => sin)
+    @test isrevertible(T) == false
+    T = Functional("x" => abs, "y" => sin)
+    @test isrevertible(T) == false
+
+    # throws
+    @test_throws ArgumentError Functional()
   end
 
   @testset "EigenAnalysis" begin

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1003,6 +1003,13 @@
 
     # throws
     @test_throws ArgumentError Functional()
+    t = Table(x = rand(15), y = rand(15))
+    T = Functional(Polynomial(1, 2, 3))
+    n, c = apply(T, t)
+    @test_throws AssertionError revert(T, n, c)
+    T = Functional(:x => abs, :y => sin)
+    n, c = apply(T, t)
+    @test_throws AssertionError revert(T, n, c)
   end
 
   @testset "EigenAnalysis" begin


### PR DESCRIPTION
This PR redesigns `Functional` implementation to add support for applying functions to specific columns.
The following constructor has been added:
```julia
Functional(col₁ => func₁, col₂ => func₂, ..., colₙ => funcₙ)
```
closes #59