### PR TITLE
fix: scale no longer converts all floats to Float64

### DIFF
--- a/src/transforms/scale.jl
+++ b/src/transforms/scale.jl
@@ -21,15 +21,16 @@ Scale(low=0.3, high=0.7)
 
 * The `low` and `high` values are restricted to the interval [0, 1].
 """
-struct Scale{T} <: Colwise
+struct Scale{T<:Real} <: Colwise
   low::T
   high::T
 
-  function Scale(low::T1, high::T2) where {T1,T2}
+  function Scale(low::T, high::T) where {T<:Real}
     @assert 0 ≤ low ≤ high ≤ 1 "invalid quantiles"
-    new{promote_type(T1, T2)}(low, high)
+    new{T}(low, high)
   end
 end
+Scale(low::Real, high::Real) = Scale(promote(low, high)...)
 
 Scale(; low=0.25, high=0.75) = Scale(low, high)
 

--- a/src/transforms/scale.jl
+++ b/src/transforms/scale.jl
@@ -30,6 +30,7 @@ struct Scale{T<:Real} <: Colwise
     new{T}(low, high)
   end
 end
+
 Scale(low::Real, high::Real) = Scale(promote(low, high)...)
 
 Scale(; low=0.25, high=0.75) = Scale(low, high)

--- a/src/transforms/scale.jl
+++ b/src/transforms/scale.jl
@@ -21,21 +21,21 @@ Scale(low=0.3, high=0.7)
 
 * The `low` and `high` values are restricted to the interval [0, 1].
 """
-struct Scale <: Colwise
-  low::Float64
-  high::Float64
+struct Scale{T} <: Colwise
+  low::T
+  high::T
 
-  function Scale(low, high)
+  function Scale(low::T1, high::T2) where {T1,T2}
     @assert 0 ≤ low ≤ high ≤ 1 "invalid quantiles"
-    new(low, high)
+    new{promote_type(T1, T2)}(low, high)
   end
 end
 
 Scale(; low=0.25, high=0.75) = Scale(low, high)
 
-assertions(::Type{Scale}) = [assert_continuous]
+assertions(::Type{<:Scale}) = [assert_continuous]
 
-isrevertible(::Type{Scale}) = true
+isrevertible(::Type{<:Scale}) = true
 
 function colcache(transform::Scale, x)
   levels = (transform.low, transform.high)
@@ -55,7 +55,7 @@ The transform that is equivalent to `Scale(low=0, high=1)`.
 
 See also [`Scale`](@ref).
 """
-MinMax() = Scale(low=0.0, high=1.0)
+MinMax() = Scale(low=0, high=1)
 
 """
     Interquartile()

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1072,6 +1072,17 @@
     @test Tables.isrowtable(n)
     rtₒ = revert(T, n, c)
     @test Tables.matrix(rt) ≈ Tables.matrix(rtₒ)
+
+    # columntype does not change
+    for FT in (Float16, Float32)
+      t = Table(; x=rand(FT, 10))
+      for T in (MinMax(), Scale(FT(0), FT(0.5)))
+        n, c = apply(T, t)
+        @test Tables.columntype(t, :x) == Tables.columntype(n, :x)
+        tₒ = revert(T, n, c)
+        @test Tables.columntype(t, :x) == Tables.columntype(tₒ, :x)
+      end
+    end
   end
 
   @testset "ZScore" begin


### PR DESCRIPTION
As noted by @eliascarv in https://github.com/JuliaML/TableTransforms.jl/issues/76#issuecomment-1128835713 `Scale` always promotes column types to `Float64`. This should fix this issue and make it work with different float types.