### PR TITLE
Fix Select inversion #76

### DIFF
--- a/src/transforms/select.jl
+++ b/src/transforms/select.jl
@@ -108,6 +108,7 @@ function revert(::Select, newtable, cache)
   # selected columns
   cols   = Tables.columns(newtable)
   select = Tables.columnnames(cols)
+  # https://github.com/JuliaML/TableTransforms.jl/issues/76
   scols  = Any[Tables.getcolumn(cols, name) for name in select]
 
   # rejected columns

--- a/src/transforms/select.jl
+++ b/src/transforms/select.jl
@@ -108,7 +108,7 @@ function revert(::Select, newtable, cache)
   # selected columns
   cols   = Tables.columns(newtable)
   select = Tables.columnnames(cols)
-  scols  = [Tables.getcolumn(cols, name) for name in select]
+  scols  = Any[Tables.getcolumn(cols, name) for name in select]
 
   # rejected columns
   reject, rcols, sperm, rinds = cache

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -103,6 +103,17 @@
     tₒ = revert(T, n, c)
     @test t == tₒ
 
+    # different columntypes
+    t = (;a=rand(3), b=rand(ComplexF64, 3))
+    T = Select(:a) → Functional(identity)
+    tₒ = revert(T, apply(T, t)...)
+    @test tₒ == t
+    @test Tables.schema(tₒ) == Tables.schema(t)
+    T = Select(:b) → Functional(identity)
+    tₒ = revert(T, apply(T, t)...)
+    @test tₒ == t
+    @test Tables.schema(tₒ) == Tables.schema(t)
+
     x1 = rand(4000)
     x2 = rand(4000)
     y1 = rand(4000)
@@ -130,15 +141,6 @@
     @test Tables.columnnames(n) == [:y1, :y2]
     rtₒ = revert(T, n, c)
     @test rt == rtₒ
-
-    # different columntypes
-    tt = (;a=rand(3), b=rand(ComplexF64, 3))
-    T = Select(:a) → Functional(identity)
-    ttₒ = revert(T, apply(T, tt)...)
-    @test ttₒ == tt && Tables.schema(ttₒ) == Tables.schema(tt)
-    T = Select(:b) → Functional(identity)
-    ttₒ = revert(T, apply(T, tt)...)
-    @test ttₒ == tt && Tables.schema(ttₒ) == Tables.schema(tt)
 
     # throws: Select without arguments
     @test_throws ArgumentError Select()

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -104,7 +104,7 @@
     @test t == tₒ
 
     # different columntypes
-    t = (;a=rand(3), b=rand(ComplexF64, 3))
+    t = (a = rand(3), b = rand(ComplexF64, 3))
     T = Select(:a) → Functional(identity)
     tₒ = revert(T, apply(T, t)...)
     @test tₒ == t

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -131,6 +131,15 @@
     rtₒ = revert(T, n, c)
     @test rt == rtₒ
 
+    # different columntypes
+    tt = (;a=rand(3), b=rand(ComplexF64, 3))
+    T = Select(:a) → Functional(identity)
+    ttₒ = revert(T, apply(T, tt)...)
+    @test ttₒ == tt && Tables.schema(ttₒ) == Tables.schema(tt)
+    T = Select(:b) → Functional(identity)
+    ttₒ = revert(T, apply(T, tt)...)
+    @test ttₒ == tt && Tables.schema(ttₒ) == Tables.schema(tt)
+
     # throws: Select without arguments
     @test_throws ArgumentError Select()
     @test_throws ArgumentError Select(())


### PR DESCRIPTION
Should fix the issue #76. I just used `Any` since it does not seem to make a performance difference.

Also the [manual](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-elaborate-container-types) notes that elaborated container types should be avoided.



For performance I used the following test functions:
```julia
function bench(inputs)
    p, table = inputs
    newtable, cache = apply(p, table)
    return revert(p, newtable, cache)
end

function setup(n, T)
    table = (; zip([Symbol(:x, k) for k=1:length(T)], [rand(t, n) for t in T])...)
    # take one column for each different columntype
    p = Select([rand(findall(x -> x == t, T)) for t in unique(T)]) → Functional(identity)
    return p, table
end
```

On 988265e6c7460e1d08c8f79fccd8301a840ba5c7
```julia
julia> @benchmark bench(inputs) setup=(inputs=setup(50000, (Float64, Float64)))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  113.585 μs … 914.030 μs  ┊ GC (min … max): 0.00% … 55.90%
 Time  (median):     124.285 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   134.002 μs ±  68.319 μs  ┊ GC (mean ± σ):  6.49% ± 10.18%

  ▇█▄▃                                                        ▁ ▁
  █████▅▄▁▁▃▁▁▃▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄█ █
  114 μs        Histogram: log(frequency) by time        650 μs <

 Memory estimate: 1.15 MiB, allocs estimate: 122.

julia> @benchmark bench(inputs) setup=(inputs=setup(50000, (Float64, Float32, Float16, Float32, Float64, ComplexF32, ComplexF32)))
BenchmarkTools.Trial: 4525 samples with 1 evaluation.
 Range (min … max):  332.164 μs …   1.740 ms  ┊ GC (min … max):  0.00% … 59.45%
 Time  (median):     366.516 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   455.282 μs ± 294.401 μs  ┊ GC (mean ± σ):  13.17% ± 14.25%

  ▅█▆▂   ▂▁                                             ▁ ▁   ▁ ▁
  ████▅▆▇██▆▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▃▃▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅██▆▄▄████▇▅▅█ █
  332 μs        Histogram: log(frequency) by time       1.58 ms <

 Memory estimate: 3.06 MiB, allocs estimate: 185.
```


With this pull request
```julia
julia> @benchmark bench(inputs) setup=(inputs=setup(50000, (Float64, Float64)))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  112.595 μs … 879.189 μs  ┊ GC (min … max): 0.00% … 56.50%
 Time  (median):     123.616 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   136.274 μs ±  84.697 μs  ┊ GC (mean ± σ):  6.84% ±  9.45%

  ██▃▂                                                          ▂
  ████▄▅▃█▇▃▁▁▁▁▃▃▁▁▅▁▁▅▅▄▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃█▅▅▁▁▁▁▁▃▁▁▁▁▁▅▇ █
  113 μs        Histogram: log(frequency) by time        794 μs <

 Memory estimate: 1.15 MiB, allocs estimate: 122.

julia> @benchmark bench(inputs) setup=(inputs=setup(50000, (Float64, Float32, Float16, Float32, Float64, ComplexF32, ComplexF32)))
BenchmarkTools.Trial: 4754 samples with 1 evaluation.
 Range (min … max):  327.364 μs …   1.610 ms  ┊ GC (min … max):  0.00% … 46.13%
 Time  (median):     358.956 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   443.015 μs ± 278.946 μs  ┊ GC (mean ± σ):  12.66% ± 13.98%

  ▅█▅▁   ▂▁                                       ▁    ▁  ▁     ▁
  ████▅▄███▅▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▄▃▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▅██▆▄▇█▇▇██▄▆█ █
  327 μs        Histogram: log(frequency) by time       1.52 ms <

 Memory estimate: 3.06 MiB, allocs estimate: 183.
```
