### PR TITLE
Add isindexable and indices to public API

### DIFF
--- a/src/TableTransforms.jl
+++ b/src/TableTransforms.jl
@@ -29,7 +29,6 @@ export
   # interface
   isrevertible,
   isindexable,
-  indices,
   apply,
   revert,
   reapply,

--- a/src/TableTransforms.jl
+++ b/src/TableTransforms.jl
@@ -28,7 +28,11 @@ include("transforms.jl")
 export
   # interface
   isrevertible,
-  apply, revert, reapply,
+  isindexable,
+  indices,
+  apply,
+  revert,
+  reapply,
 
   # built-in
   Select,

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -35,6 +35,15 @@ Tells whether or not the `transform` is revertible, i.e. supports a
 function isrevertible end
 
 """
+    isindexable(transform)
+
+Tells whether or not the `transform` is indexable, i.e. can be
+implemented in terms of row [`indices`](@ref). Defaults to `false`
+for new types.
+"""
+function isindexable end
+
+"""
     newtable, cache = apply(transform, table)
 
 Apply the `transform` on the `table`. Return the `newtable` and a
@@ -52,6 +61,16 @@ Only defined when the `transform` [`isrevertible`](@ref).
 function revert end
 
 """
+    newinds, cache = indices(transform, table)
+
+Return indices `newinds` of rows of original `table` corresponding to
+the `newtable` that would be obtained by applying the `transform` with
+with the [`apply`](@ref) function, and a `cache`. Only defined when the
+`transform` [`isindexable`](@ref).
+"""
+function indices end
+
+"""
     Stateless
 
 This trait is useful to signal that we can [`reapply`](@ref) a transform
@@ -60,7 +79,7 @@ This trait is useful to signal that we can [`reapply`](@ref) a transform
 abstract type Stateless <: Transform end
 
 """
-    reapply(transform, table, cache)
+    newtable = reapply(transform, table, cache)
 
 Reapply the `transform` to (a possibly different) `table` using a `cache`
 that was created with a previous [`apply`](@ref) call.
@@ -110,6 +129,9 @@ assertions(::Type{<:Transform}) = []
 
 isrevertible(transform::Transform) = isrevertible(typeof(transform))
 isrevertible(::Type{<:Transform}) = false
+
+isindexable(transform::Transform) = isindexable(typeof(transform))
+isindexable(::Type{<:Transform}) = false
 
 (transform::Transform)(table) = apply(transform, table) |> first
 

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -560,7 +560,7 @@
     @test t == tₒ
 
     @test isindexable(T)
-    inds, _ = indices(T, t)
+    inds, _ = TableTransforms.indices(T, t)
     @test sort(inds) == 1:4
 
     # descending order test
@@ -650,7 +650,7 @@
 
     @test !isrevertible(T)
     @test isindexable(T)
-    inds, _ = indices(T, t)
+    inds, _ = TableTransforms.indices(T, t)
     @test inds ⊆ 1:6
 
     T = Sample(6, replace=false)
@@ -724,7 +724,7 @@
 
     # indexable test
     @test isindexable(T) == true
-    inds, _ = indices(T, t)
+    inds, _ = TableTransforms.indices(T, t)
     @test inds == [1, 2, 6]
 
     T = Filter(row -> any(>(5), row))

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -554,9 +554,14 @@
     @test n.b == [8, 5, 4, 2]
     @test n.c == [1, 4, 2, 3]
     @test n.d == [7, 5, 3, 4]
-    @test isrevertible(T) == true
+
+    @test isrevertible(T)
     tₒ = revert(T, n, c)
     @test t == tₒ
+
+    @test isindexable(T)
+    inds, _ = indices(T, t)
+    @test sort(inds) == 1:4
 
     # descending order test
     T = Sort(:b, rev=true)
@@ -643,6 +648,11 @@
     n, c = apply(T, t)
     @test length(n.a) == 30
 
+    @test !isrevertible(T)
+    @test isindexable(T)
+    inds, _ = indices(T, t)
+    @test inds ⊆ 1:6
+
     T = Sample(6, replace=false)
     n, c = apply(T, t)
     @test n.a ⊆ t.a
@@ -708,9 +718,14 @@
     @test n.f == [4, 4, 2]
 
     # revert test
-    @test isrevertible(T) == true
+    @test isrevertible(T)
     tₒ = revert(T, n, c)
     @test t == tₒ
+
+    # indexable test
+    @test isindexable(T) == true
+    inds, _ = indices(T, t)
+    @test inds == [1, 2, 6]
 
     T = Filter(row -> any(>(5), row))
     n, c = apply(T, t)
@@ -790,7 +805,7 @@
     @test n.f == [4, 5]
 
     # revert test
-    @test isrevertible(T) == true
+    @test isrevertible(T)
     tₒ = revert(T, n, c)
     cols = Tables.columns(t)
     colsₒ = Tables.columns(tₒ)
@@ -993,7 +1008,7 @@
     @test n.d == [4, 3, 7, -5, 4, -1]
     @test n.e == [-5, -5, 2, 6, -5, 2]
     @test n.f == [4, 4, 3, 4, -5, 2]
-    @test isrevertible(T) == true
+    @test isrevertible(T)
     tₒ = revert(T, n, c)
     @test t == tₒ
 
@@ -1085,7 +1100,7 @@
     @test n.f == [4, 0, 3, 4, 5, 2]
 
     # revert test
-    @test isrevertible(T) == true
+    @test isrevertible(T)
     tₒ = revert(T, n, c)
     cols = Tables.columns(t)
     colsₒ = Tables.columns(tₒ)
@@ -1574,7 +1589,7 @@
     T = Functional(x -> x)
     n, c = apply(T, t)
     @test t == n
-    @test isrevertible(T) == false
+    @test !isrevertible(T)
 
     # functor tests
     x = rand(1500)
@@ -1587,7 +1602,7 @@
     @test f.(y) == n.y
     @test all(≥(1), n.x)
     @test all(≥(1), n.y)
-    @test isrevertible(T) == false
+    @test !isrevertible(T)
 
     # apply functions to specific columns
     x = π*rand(1500)
@@ -1627,17 +1642,17 @@
     @test Tables.matrix(t) ≈ Tables.matrix(tₒ)
 
     T = Functional(1 => cos, 2 => sin)
-    @test isrevertible(T) == true
+    @test isrevertible(T)
     T = Functional(:x => cos, :y => sin)
-    @test isrevertible(T) == true
+    @test isrevertible(T)
     T = Functional("x" => cos, "y" => sin)
-    @test isrevertible(T) == true
+    @test isrevertible(T)
     T = Functional(1 => abs, 2 => sin)
-    @test isrevertible(T) == false
+    @test !isrevertible(T)
     T = Functional(:x => abs, :y => sin)
-    @test isrevertible(T) == false
+    @test !isrevertible(T)
     T = Functional("x" => abs, "y" => sin)
-    @test isrevertible(T) == false
+    @test !isrevertible(T)
 
     # row table
     x = π*rand(1500)


### PR DESCRIPTION
Some transforms such as Filter, Sample, and Sort are implemented in terms of row indices. This PR introduces two new trait functions to the public API to facilitate extensions downstream.

@eliascarv I didn't test performance regressions. It would be nice to double check, particularly in the case of Filter if we are doing something suboptimal.