### PR TITLE
Add support for metadata

### DIFF
--- a/src/TableTransforms.jl
+++ b/src/TableTransforms.jl
@@ -20,6 +20,7 @@ using Random
 import Distributions: ContinuousUnivariateDistribution
 import Distributions: quantile, cdf
 
+include("tabletraits.jl")
 include("assertions.jl")
 include("distributions.jl")
 include("colspec.jl")
@@ -28,7 +29,9 @@ include("transforms.jl")
 export
   # interface
   isrevertible,
-  apply, revert, reapply,
+  apply,
+  revert,
+  reapply,
 
   # built-in
   Select,

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 """
-    features, metadata = split(table)
+    features, metadata = divide(table)
 
 Divide the `table` into a table with `features` and
 a `metadata` object, e.g. geospatial domain.
@@ -11,7 +11,7 @@ a `metadata` object, e.g. geospatial domain.
 divide(table) = table, nothing
 
 """
-    table = combine(features, metadata)
+    table = attach(features, metadata)
 
 Combine a table with `features` and a `metadata`
 object into a special type of `table`.

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    features, metadata = split(table)
+
+Divide the `table` into a table with `features` and
+a `metadata` object, e.g. geospatial domain.
+"""
+divide(table) = table, nothing
+
+"""
+    table = combine(features, metadata)
+
+Combine a table with `features` and a `metadata`
+object into a special type of `table`.
+"""
+attach(features, ::Nothing) = features

--- a/src/transforms/coerce.jl
+++ b/src/transforms/coerce.jl
@@ -27,7 +27,7 @@ Coerce(pair::Pair{Symbol,<:Type}...; tight=false, verbosity=1) =
 
 isrevertible(::Type{<:Coerce}) = true
 
-function apply(transform::Coerce, table)
+function applyfeat(transform::Coerce, table)
   newtable = coerce(table, transform.pairs...;
                     tight=transform.tight,
                     verbosity=transform.verbosity)
@@ -37,7 +37,7 @@ function apply(transform::Coerce, table)
   newtable, types
 end
 
-function revert(transform::Coerce, newtable, cache)
+function revertfeat(::Coerce, newtable, cache)
   cols = Tables.columns(newtable)
   names = Tables.columnnames(cols)
   

--- a/src/transforms/coltable.jl
+++ b/src/transforms/coltable.jl
@@ -11,6 +11,6 @@ struct ColTable <: Stateless end
 
 isrevertible(::Type{ColTable}) = true
 
-apply(::ColTable, table) = Tables.columntable(table), table
+applyfeat(::ColTable, table) = Tables.columntable(table), table
 
-revert(::ColTable, newtable, cache) = cache
+revertfeat(::ColTable, newtable, cache) = cache

--- a/src/transforms/eigenanalysis.jl
+++ b/src/transforms/eigenanalysis.jl
@@ -58,7 +58,7 @@ assertions(::Type{EigenAnalysis}) = [assert_continuous]
 
 isrevertible(::Type{EigenAnalysis}) = true
 
-function apply(transform::EigenAnalysis, table)
+function applyfeat(transform::EigenAnalysis, table)
   # basic checks
   for assertion in assertions(transform)
     assertion(table)
@@ -91,7 +91,7 @@ function apply(transform::EigenAnalysis, table)
   newtable, (μ, S, S⁻¹, onames)
 end
 
-function revert(::EigenAnalysis, newtable, cache)
+function revertfeat(::EigenAnalysis, newtable, cache)
   # table as matrix
   Z = Tables.matrix(newtable)
 
@@ -109,7 +109,7 @@ function revert(::EigenAnalysis, newtable, cache)
   𝒯 |> Tables.materializer(newtable)
 end
 
-function reapply(transform::EigenAnalysis, table, cache)
+function reapplyfeat(transform::EigenAnalysis, table, cache)
   # basic checks
   for assertion in assertions(transform)
     assertion(table)

--- a/src/transforms/filter.jl
+++ b/src/transforms/filter.jl
@@ -24,7 +24,7 @@ end
 
 isrevertible(::Type{<:Filter}) = true
 
-function apply(transform::Filter, table)
+function applyfeat(transform::Filter, table)
   rows = Tables.rowtable(table)
 
   # selected and rejected rows/inds
@@ -38,7 +38,7 @@ function apply(transform::Filter, table)
   newtable, zip(rinds, rrows)
 end
 
-function revert(::Filter, newtable, cache)
+function revertfeat(::Filter, newtable, cache)
   rows = Tables.rowtable(newtable)
 
   for (i, row) in cache
@@ -102,14 +102,14 @@ _nonmissing(::Type{T}, x) where {T} = x
 _nonmissing(::Type{Union{Missing,T}}, x) where {T} = collect(T, x)
 _nonmissing(x) = _nonmissing(eltype(x), x)
 
-function apply(transform::DropMissing, table)
+function applyfeat(transform::DropMissing, table)
   schema = Tables.schema(table)
   names  = schema.names
   types  = schema.types
   snames = choose(transform.colspec, names)
   ftrans = _ftrans(transform, snames)
 
-  newtable, fcache = apply(ftrans, table)
+  newtable, fcache = applyfeat(ftrans, table)
 
   # drop Missing type
   ncols = Tables.columns(newtable)
@@ -125,7 +125,7 @@ function apply(transform::DropMissing, table)
   ptable, (ftrans, fcache, types)
 end
 
-function revert(::DropMissing, newtable, cache)
+function revertfeat(::DropMissing, newtable, cache)
   ftrans, fcache, types = cache
 
   # pre-processing
@@ -138,5 +138,5 @@ function revert(::DropMissing, newtable, cache)
   𝒯 = (; zip(names, pcols)...)
   ptable = 𝒯 |> Tables.materializer(newtable)
 
-  revert(ftrans, ptable, fcache)
+  revertfeat(ftrans, ptable, fcache)
 end

--- a/src/transforms/functional.jl
+++ b/src/transforms/functional.jl
@@ -58,7 +58,7 @@ isrevertible(transform::Functional) =
 _funcdict(func, names) = Dict(nm => func for nm in names)
 _funcdict(func::Tuple, names) = Dict(names .=> func)
 
-function apply(transform::Functional, table) 
+function applyfeat(transform::Functional, table) 
   cols = Tables.columns(table)
   names = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)
@@ -80,7 +80,7 @@ function apply(transform::Functional, table)
   return newtable, (snames, funcs)
 end
 
-function revert(transform::Functional, newtable, cache)
+function revertfeat(transform::Functional, newtable, cache)
   @assert isrevertible(transform) "Transform is not revertible."
 
   cols = Tables.columns(newtable)

--- a/src/transforms/identity.jl
+++ b/src/transforms/identity.jl
@@ -11,6 +11,6 @@ struct Identity <: Stateless end
 
 isrevertible(::Type{Identity}) = true
 
-apply(::Identity, table) = table, nothing
+applyfeat(::Identity, table) = table, nothing
 
-revert(::Identity, newtable, cache) = newtable
+revertfeat(::Identity, newtable, cache) = newtable

--- a/src/transforms/levels.jl
+++ b/src/transforms/levels.jl
@@ -29,7 +29,7 @@ Levels(; kwargs...) = throw(ArgumentError("Cannot create a Levels object without
 
 isrevertible(transform::Levels) = true
 
-function apply(transform::Levels, table)
+function applyfeat(transform::Levels, table)
   cols = Tables.columns(table)
   names = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)
@@ -59,10 +59,11 @@ function apply(transform::Levels, table)
 
   𝒯 = (; zip(names, columns)...)
   newtable = 𝒯 |> Tables.materializer(table)
+
   newtable, cache
 end
 
-function revert(::Levels, newtable, cache)
+function revertfeat(::Levels, newtable, cache)
   cols = Tables.columns(newtable)
   names = Tables.columnnames(cols)
 

--- a/src/transforms/onehot.jl
+++ b/src/transforms/onehot.jl
@@ -26,7 +26,7 @@ end
 
 isrevertible(::Type{<:OneHot}) = true
 
-function apply(transform::OneHot, table)
+function applyfeat(transform::OneHot, table)
   cols = Tables.columns(table)
   names = Tables.columnnames(cols) |> collect
   columns = Any[Tables.getcolumn(cols, nm) for nm in names]
@@ -58,7 +58,7 @@ function apply(transform::OneHot, table)
   newtable, (name, inds, xl, isordered(x))
 end
 
-function revert(::OneHot, newtable, cache)
+function revertfeat(::OneHot, newtable, cache)
   cols = Tables.columns(newtable)
   names = Tables.columnnames(cols) |> collect
   columns = Any[Tables.getcolumn(cols, nm) for nm in names]

--- a/src/transforms/rename.jl
+++ b/src/transforms/rename.jl
@@ -33,7 +33,7 @@ Rename(pairs::Pair{T,S}...) where {T<:Col,S<:AbstractString} =
 
 isrevertible(::Type{<:Rename}) = true
 
-function apply(transform::Rename, table)
+function applyfeat(transform::Rename, table)
   cols   = Tables.columns(table)
   names  = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)
@@ -48,7 +48,7 @@ function apply(transform::Rename, table)
   newtable, names
 end
 
-function revert(::Transform, newtable, cache)
+function revertfeat(::Rename, newtable, cache)
   cols    = Tables.columns(newtable)
   names   = Tables.columnnames(cols)
   columns = [Tables.getcolumn(cols, nm) for nm in names]

--- a/src/transforms/rowtable.jl
+++ b/src/transforms/rowtable.jl
@@ -11,6 +11,6 @@ struct RowTable <: Stateless end
 
 isrevertible(::Type{RowTable}) = true
 
-apply(::RowTable, table) = Tables.rowtable(table), table
+applyfeat(::RowTable, table) = Tables.rowtable(table), table
 
-revert(::RowTable, newtable, cache) = cache
+revertfeat(::RowTable, newtable, cache) = cache

--- a/src/transforms/sample.jl
+++ b/src/transforms/sample.jl
@@ -48,7 +48,7 @@ Sample(size::Int, weights; kwargs...) =
 
 isrevertible(::Type{<:Sample}) = false
 
-function apply(transform::Sample, table)
+function applyfeat(transform::Sample, table)
   rows = Tables.rowtable(table)
 
   size    = transform.size

--- a/src/transforms/select.jl
+++ b/src/transforms/select.jl
@@ -99,7 +99,7 @@ isrevertible(::Type{<:Select}) = true
 _newnames(::Nothing, select) = select
 _newnames(names::Vector{Symbol}, select) = names
 
-function apply(transform::Select, table)
+function applyfeat(transform::Select, table)
   # original columns
   cols = Tables.columns(table)
 
@@ -122,7 +122,7 @@ function apply(transform::Select, table)
   TableSelection(table, names, select), (select, sperm, reject, rcolumns, rinds)
 end
 
-function revert(::Select, newtable, cache)
+function revertfeat(::Select, newtable, cache)
   # selected columns
   cols  = Tables.columns(newtable)
   names = Tables.columnnames(cols)
@@ -145,7 +145,7 @@ function revert(::Select, newtable, cache)
 end
 
 # reverting a single TableSelection is trivial
-revert(::Select, newtable::TableSelection, cache) = newtable.table
+revertfeat(::Select, newtable::TableSelection, cache) = newtable.table
 
 """
     Reject(col₁, col₂, ..., colₙ)
@@ -182,17 +182,17 @@ Reject(::AllSpec) = throw(ArgumentError("Cannot reject all columns."))
 
 isrevertible(::Type{<:Reject}) = true
 
-function apply(transform::Reject, table)
+function applyfeat(transform::Reject, table)
   cols    = Tables.columns(table)
   allcols = Tables.columnnames(cols)
   reject  = choose(transform.colspec, allcols)
   select  = setdiff(allcols, reject)
   strans  = Select(select)
-  newtable, scache = apply(strans, table)
+  newtable, scache = applyfeat(strans, table)
   newtable, (strans, scache)
 end
 
-function revert(::Reject, newtable, cache)
+function revertfeat(::Reject, newtable, cache)
   strans, scache = cache
-  revert(strans, newtable, scache)
+  revertfeat(strans, newtable, scache)
 end

--- a/src/transforms/sort.jl
+++ b/src/transforms/sort.jl
@@ -38,7 +38,7 @@ Sort(; kwargs...) = throw(ArgumentError("Cannot create a Sort object without arg
 
 isrevertible(::Type{<:Sort}) = true
 
-function apply(transform::Sort, table)
+function applyfeat(transform::Sort, table)
   cols = Tables.columns(table)
   names = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)
@@ -55,7 +55,7 @@ function apply(transform::Sort, table)
   newtable, inds
 end
 
-function revert(::Sort, newtable, cache)
+function revertfeat(::Sort, newtable, cache)
   # use cache to recalculate old order
   inds = sortperm(cache)
 

--- a/src/transforms/stdnames.jl
+++ b/src/transforms/stdnames.jl
@@ -22,7 +22,7 @@ StdNames() = StdNames(:upper)
 
 isrevertible(::Type{StdNames}) = true
 
-function apply(transform::StdNames, table)  
+function applyfeat(transform::StdNames, table)  
   # retrieve spec
   spec = transform.spec
   
@@ -43,14 +43,14 @@ function apply(transform::StdNames, table)
   
   # rename transform
   rtrans = Rename(colspec(oldnames), Symbol.(newnames))
-  newtable, rcache = apply(rtrans, table)
+  newtable, rcache = applyfeat(rtrans, table)
 
   newtable, (rtrans, rcache)
 end
 
-function revert(::StdNames, newtable, cache)
+function revertfeat(::StdNames, newtable, cache)
   rtrans, rcache = cache
-  revert(rtrans, newtable, rcache)
+  revertfeat(rtrans, newtable, rcache)
 end
 
 const delim = [' ', '\t', '-', '_']


### PR DESCRIPTION
Fixes #114 

This PR generalizes our API to handle metadata. I needed to introduce two new trait functions `divide` and `attach` to be implemented by table types in order to seamlessly integrate with all our transforms.