### PR TITLE
Add preprocess

### DIFF
--- a/src/transforms/coerce.jl
+++ b/src/transforms/coerce.jl
@@ -27,7 +27,7 @@ Coerce(pair::Pair{Symbol,<:Type}...; tight=false, verbosity=1) =
 
 isrevertible(::Type{<:Coerce}) = true
 
-function applyfeat(transform::Coerce, table)
+function applyfeat(transform::Coerce, table, prep)
   newtable = coerce(table, transform.pairs...;
                     tight=transform.tight,
                     verbosity=transform.verbosity)

--- a/src/transforms/coltable.jl
+++ b/src/transforms/coltable.jl
@@ -11,6 +11,6 @@ struct ColTable <: Stateless end
 
 isrevertible(::Type{ColTable}) = true
 
-applyfeat(::ColTable, table) = Tables.columntable(table), table
+applyfeat(::ColTable, table, prep) = Tables.columntable(table), table
 
 revertfeat(::ColTable, newtable, cache) = cache

--- a/src/transforms/eigenanalysis.jl
+++ b/src/transforms/eigenanalysis.jl
@@ -58,7 +58,7 @@ assertions(::Type{EigenAnalysis}) = [assert_continuous]
 
 isrevertible(::Type{EigenAnalysis}) = true
 
-function applyfeat(transform::EigenAnalysis, table)
+function applyfeat(transform::EigenAnalysis, table, prep)
   # basic checks
   for assertion in assertions(transform)
     assertion(table)

--- a/src/transforms/filter.jl
+++ b/src/transforms/filter.jl
@@ -24,7 +24,7 @@ end
 
 isrevertible(::Type{<:Filter}) = true
 
-function applyfeat(transform::Filter, table)
+function applyfeat(transform::Filter, table, prep)
   rows = Tables.rowtable(table)
 
   # selected and rejected rows/inds
@@ -102,14 +102,14 @@ _nonmissing(::Type{T}, x) where {T} = x
 _nonmissing(::Type{Union{Missing,T}}, x) where {T} = collect(T, x)
 _nonmissing(x) = _nonmissing(eltype(x), x)
 
-function applyfeat(transform::DropMissing, table)
+function applyfeat(transform::DropMissing, table, prep)
   schema = Tables.schema(table)
   names  = schema.names
   types  = schema.types
   snames = choose(transform.colspec, names)
   ftrans = _ftrans(transform, snames)
 
-  newtable, fcache = applyfeat(ftrans, table)
+  newtable, fcache = applyfeat(ftrans, table, nothing)
 
   # drop Missing type
   ncols = Tables.columns(newtable)

--- a/src/transforms/functional.jl
+++ b/src/transforms/functional.jl
@@ -58,7 +58,7 @@ isrevertible(transform::Functional) =
 _funcdict(func, names) = Dict(nm => func for nm in names)
 _funcdict(func::Tuple, names) = Dict(names .=> func)
 
-function applyfeat(transform::Functional, table) 
+function applyfeat(transform::Functional, table, prep) 
   cols = Tables.columns(table)
   names = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)

--- a/src/transforms/identity.jl
+++ b/src/transforms/identity.jl
@@ -11,6 +11,6 @@ struct Identity <: Stateless end
 
 isrevertible(::Type{Identity}) = true
 
-applyfeat(::Identity, table) = table, nothing
+apply(::Identity, table) = table, nothing
 
-revertfeat(::Identity, newtable, cache) = newtable
+revert(::Identity, newtable, cache) = newtable

--- a/src/transforms/levels.jl
+++ b/src/transforms/levels.jl
@@ -29,7 +29,7 @@ Levels(; kwargs...) = throw(ArgumentError("Cannot create a Levels object without
 
 isrevertible(transform::Levels) = true
 
-function applyfeat(transform::Levels, table)
+function applyfeat(transform::Levels, table, prep)
   cols = Tables.columns(table)
   names = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)

--- a/src/transforms/onehot.jl
+++ b/src/transforms/onehot.jl
@@ -26,7 +26,7 @@ end
 
 isrevertible(::Type{<:OneHot}) = true
 
-function applyfeat(transform::OneHot, table)
+function applyfeat(transform::OneHot, table, prep)
   cols = Tables.columns(table)
   names = Tables.columnnames(cols) |> collect
   columns = Any[Tables.getcolumn(cols, nm) for nm in names]

--- a/src/transforms/rename.jl
+++ b/src/transforms/rename.jl
@@ -33,7 +33,7 @@ Rename(pairs::Pair{T,S}...) where {T<:Col,S<:AbstractString} =
 
 isrevertible(::Type{<:Rename}) = true
 
-function applyfeat(transform::Rename, table)
+function applyfeat(transform::Rename, table, prep)
   cols   = Tables.columns(table)
   names  = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)

--- a/src/transforms/rowtable.jl
+++ b/src/transforms/rowtable.jl
@@ -11,6 +11,6 @@ struct RowTable <: Stateless end
 
 isrevertible(::Type{RowTable}) = true
 
-applyfeat(::RowTable, table) = Tables.rowtable(table), table
+applyfeat(::RowTable, table, prep) = Tables.rowtable(table), table
 
 revertfeat(::RowTable, newtable, cache) = cache

--- a/src/transforms/sample.jl
+++ b/src/transforms/sample.jl
@@ -48,7 +48,7 @@ Sample(size::Int, weights; kwargs...) =
 
 isrevertible(::Type{<:Sample}) = false
 
-function applyfeat(transform::Sample, table)
+function applyfeat(transform::Sample, table, prep)
   rows = Tables.rowtable(table)
 
   size    = transform.size

--- a/src/transforms/select.jl
+++ b/src/transforms/select.jl
@@ -99,7 +99,7 @@ isrevertible(::Type{<:Select}) = true
 _newnames(::Nothing, select) = select
 _newnames(names::Vector{Symbol}, select) = names
 
-function applyfeat(transform::Select, table)
+function applyfeat(transform::Select, table, prep)
   # original columns
   cols = Tables.columns(table)
 
@@ -182,13 +182,13 @@ Reject(::AllSpec) = throw(ArgumentError("Cannot reject all columns."))
 
 isrevertible(::Type{<:Reject}) = true
 
-function applyfeat(transform::Reject, table)
+function applyfeat(transform::Reject, table, prep)
   cols    = Tables.columns(table)
   allcols = Tables.columnnames(cols)
   reject  = choose(transform.colspec, allcols)
   select  = setdiff(allcols, reject)
   strans  = Select(select)
-  newtable, scache = applyfeat(strans, table)
+  newtable, scache = applyfeat(strans, table, nothing)
   newtable, (strans, scache)
 end
 

--- a/src/transforms/sort.jl
+++ b/src/transforms/sort.jl
@@ -38,7 +38,7 @@ Sort(; kwargs...) = throw(ArgumentError("Cannot create a Sort object without arg
 
 isrevertible(::Type{<:Sort}) = true
 
-function applyfeat(transform::Sort, table)
+function applyfeat(transform::Sort, table, prep)
   cols = Tables.columns(table)
   names = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)

--- a/src/transforms/stdnames.jl
+++ b/src/transforms/stdnames.jl
@@ -22,7 +22,7 @@ StdNames() = StdNames(:upper)
 
 isrevertible(::Type{StdNames}) = true
 
-function applyfeat(transform::StdNames, table)  
+function applyfeat(transform::StdNames, table, prep)  
   # retrieve spec
   spec = transform.spec
   
@@ -43,7 +43,7 @@ function applyfeat(transform::StdNames, table)
   
   # rename transform
   rtrans = Rename(colspec(oldnames), Symbol.(newnames))
-  newtable, rcache = applyfeat(rtrans, table)
+  newtable, rcache = applyfeat(rtrans, table, nothing)
 
   newtable, (rtrans, rcache)
 end


### PR DESCRIPTION
This PR introduces a new preprocess function to be used by transforms such as Filter, Sort, etc. which can be expressed in terms of an intermediate representation (e.g. indices).