### PR TITLE
Fix Parallel transform in the presence of metadata

### DIFF
--- a/src/transforms/parallel.jl
+++ b/src/transforms/parallel.jl
@@ -42,9 +42,9 @@ function apply(p::Parallel, table)
   caches = last.(vals)
 
   # features and metadata
-  divid = divide.(tables)
-  feats = first.(divid)
-  metas = last.(divid)
+  splits = divide.(tables)
+  feats  = first.(splits)
+  metas  = last.(splits)
 
   # table with concatenated features
   newfeat = tablehcat(feats)

--- a/src/transforms/parallel.jl
+++ b/src/transforms/parallel.jl
@@ -120,9 +120,9 @@ function reapply(p::Parallel, table, cache)
   tables  = tcollect(f(t, c) for (t, c) in itr)
 
   # features and metadata
-  divid = divide.(tables)
-  feats = first.(divid)
-  metas = last.(divid)
+  splits = divide.(tables)
+  feats  = first.(splits)
+  metas  = last.(splits)
 
   # table with concatenated features
   newfeat = tablehcat(feats)


### PR DESCRIPTION
This is a hotfix for the Parallel transform. I started playing with more complex pipelines and realized that we didn't have this case covered in our tests. In a future PR we should consider introducing a dummy table type with metadata in our test suite.