### PR TITLE
Refactor Scale

### DIFF
--- a/src/transforms/scale.jl
+++ b/src/transforms/scale.jl
@@ -35,16 +35,19 @@ Scale(r"[ace]", low=0.3, high=0.7)
 
 * The `low` and `high` values are restricted to the interval [0, 1].
 """
-struct Scale{S<:ColSpec} <: ColwiseFeatureTransform
+struct Scale{S<:ColSpec,T} <: ColwiseFeatureTransform
   colspec::S
-  low::Float64
-  high::Float64
+  low::T
+  high::T
 
-  function Scale(colspec::S, low, high) where {S<:ColSpec}
+  function Scale(colspec::S, low::T, high::T) where {S<:ColSpec,T}
     @assert 0 ≤ low ≤ high ≤ 1 "invalid quantiles"
-    new{S}(colspec, low, high)
+    new{S,T}(colspec, low, high)
   end
 end
+
+Scale(colspec::ColSpec, low, high) = 
+  Scale(colspec, promote(low, high)...)
 
 Scale(; low=0.25, high=0.75) = Scale(AllSpec(), low, high)
 Scale(spec; low=0.25, high=0.75) = Scale(colspec(spec), low, high)

--- a/src/transforms/scale.jl
+++ b/src/transforms/scale.jl
@@ -60,7 +60,7 @@ function colcache(transform::Scale, x)
   high = convert(eltype(x), transform.high)
   xl, xh = quantile(x, (low, high))
   xl == xh && ((xl, xh) = (zero(xl), one(xh)))
-  (xl=xl, xh=xh)
+  (; xl, xh)
 end
 
 colapply(::Scale, x, c)  = @. (x - c.xl) / (c.xh - c.xl)

--- a/test/shows.jl
+++ b/test/shows.jl
@@ -343,7 +343,7 @@
 
     # compact mode
     iostr = sprint(show, pipeline)
-    @test iostr == "Select([:x, :z], nothing) → ZScore(all) → Scale(all, 0, 1)"
+    @test iostr == "Select([:x, :z], nothing) → ZScore(all) → Scale(all, 0.0, 1.0)"
 
     # full mode
     iostr = sprint(show, MIME("text/plain"), pipeline)
@@ -351,7 +351,7 @@
     SequentialTransform
     ├─ Select([:x, :z], nothing)
     ├─ ZScore(all)
-    └─ Scale(all, 0, 1)"""
+    └─ Scale(all, 0.0, 1.0)"""
   end
 
   @testset "ParallelTableTransform" begin

--- a/test/shows.jl
+++ b/test/shows.jl
@@ -343,7 +343,7 @@
 
     # compact mode
     iostr = sprint(show, pipeline)
-    @test iostr == "Select([:x, :z], nothing) → ZScore(all) → Scale(all, 0.0, 1.0)"
+    @test iostr == "Select([:x, :z], nothing) → ZScore(all) → Scale(all, 0, 1)"
 
     # full mode
     iostr = sprint(show, MIME("text/plain"), pipeline)
@@ -351,7 +351,7 @@
     SequentialTransform
     ├─ Select([:x, :z], nothing)
     ├─ ZScore(all)
-    └─ Scale(all, 0.0, 1.0)"""
+    └─ Scale(all, 0, 1)"""
   end
 
   @testset "ParallelTableTransform" begin

--- a/test/transforms/scale.jl
+++ b/test/transforms/scale.jl
@@ -42,7 +42,7 @@
   # columntype does not change
   for FT in (Float16, Float32)
     t = Table(; x=rand(FT, 10))
-    for T in (MinMax(), Scale(low=0, high=0.5))
+    for T in (MinMax(), Interquartile(), Scale(low=0, high=0.5))
       n, c = apply(T, t)
       @test Tables.columntype(t, :x) == Tables.columntype(n, :x)
       tₒ = revert(T, n, c)

--- a/test/transforms/scale.jl
+++ b/test/transforms/scale.jl
@@ -42,7 +42,7 @@
   # columntype does not change
   for FT in (Float16, Float32)
     t = Table(; x=rand(FT, 10))
-    for T in (MinMax(), Scale(low=FT(0), high=FT(0.5)))
+    for T in (MinMax(), Scale(low=0, high=0.5))
       n, c = apply(T, t)
       @test Tables.columntype(t, :x) == Tables.columntype(n, :x)
       tₒ = revert(T, n, c)


### PR DESCRIPTION
This PR makes Scale constructor simpler and avoids type conversion in `apply(transform, table)`.