### PR TITLE
Fix bug in `Tables.getcolumn(t::TableSelection, i::Int)`

### DIFF
--- a/src/tableselection.jl
+++ b/src/tableselection.jl
@@ -43,7 +43,7 @@ Tables.columnnames(t::TableSelection) = t.names
 
 function Tables.getcolumn(t::TableSelection, i::Int)
   i > t.ncols && error("Table has no column with index $i.")
-  Tables.getcolumn(t.cols, t.names[i])
+  Tables.getcolumn(t.cols, t.mapnames[t.names[i]])
 end
 
 function Tables.getcolumn(t::TableSelection, nm::Symbol)

--- a/test/tableselection.jl
+++ b/test/tableselection.jl
@@ -36,6 +36,9 @@
     @test Tables.getcolumn(s, :x) == t.c
     @test Tables.getcolumn(s, :y) == t.d
     @test Tables.getcolumn(s, :z) == t.f
+    @test Tables.getcolumn(s, 1)  == t.c
+    @test Tables.getcolumn(s, 2)  == t.d
+    @test Tables.getcolumn(s, 3)  == t.f
   
     # row table
     select = [:a, :b, :e]


### PR DESCRIPTION
Code:
```julia
julia> using TableTransforms

julia> using Tables

julia> using TypedTables

julia> table = Table(
           a = 1:5,
           b = 6:10,
           c = 11:15,
           d = 16:20
       );

julia> transf = Select(:a => :x, :d => :y)
Select transform
├─ colspec = [:a, :d]
└─ newnames = [:x, :y]

julia> newtable, cache = apply(transf, table);

julia> newtable
TableSelection
┌───────┬───────┐
│     x │     y │
│ Int64 │ Int64 │
├───────┼───────┤
│     1 │    16 │
│     2 │    17 │
│     3 │    18 │
│     4 │    19 │
│     5 │    20 │
└───────┴───────┘
```
master:
```julia
julia> Tables.getcolumn(newtable, 1)
ERROR: type NamedTuple has no field x
Stacktrace:
 [1] getproperty
   @ .\Base.jl:38 [inlined]
 [2] getcolumn
   @ C:\Users\Dev01\.julia\packages\Tables\T7rHm\src\Tables.jl:102 [inlined]
 [3] getcolumn(t::TableTransforms.TableSelection{Table{NamedTuple{(:a, :b, :c, :d), NTuple{4, Int64}}, 1, NamedTuple{(:a, :b, :c, :d), NTuple{4, UnitRange{Int64}}}}, NamedTuple{(:a, :b, :c, :d), NTuple{4, UnitRange{Int64}}}}, i::Int64) 
   @ TableTransforms c:\Users\Dev01\Documents\Elias\TableTransforms.jl\src\tableselection.jl:46
 [4] top-level scope
   @ REPL[9]:1
```
This PR:
```julia
julia> Tables.getcolumn(newtable, 1)
1:5

julia> Tables.getcolumn(newtable, 2)
16:20
```