### PR TITLE
fixed AssertionError

### DIFF
--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -171,14 +171,15 @@ reapply(transform::StatelessFeatureTransform, table, cache) =
 
 function applyfeat(transform::ColwiseFeatureTransform, feat, prep)
   # retrieve column names and values
-  cols   = Tables.columns(feat) 
+  cols   = Tables.columns(feat)
   names  = Tables.columnnames(cols)
-  snames = choose(transform.colspec, names) 
+  snames = choose(transform.colspec, names)
+  scols = feat |> Select(snames)
 
-  # basic checks 
-  for assertion in assertions(transform) 
+  # basic checks
+  for assertion in assertions(transform)
     # Perform the assertion on the selected columns of the input table
-    assertion(feat |> Select(snames)) 
+    assertion(scols)
   end
   
   # function to transform a single column

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -178,7 +178,7 @@ function applyfeat(transform::ColwiseFeatureTransform, feat, prep)
   # basic checks 
   for assertion in assertions(transform) 
     # Perform the assertion on the selected columns of the input table
-    assertion(feat[:, snames]) 
+    assertion(feat |> Select(snames)) 
   end
   
   # function to transform a single column

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -174,12 +174,12 @@ function applyfeat(transform::ColwiseFeatureTransform, feat, prep)
   cols   = Tables.columns(feat)
   names  = Tables.columnnames(cols)
   snames = choose(transform.colspec, names)
-  scols = feat |> Select(snames)
+  sfeat  = feat |> Select(snames)
 
   # basic checks
   for assertion in assertions(transform)
     # Perform the assertion on the selected columns of the input table
-    assertion(scols)
+    assertion(sfeat)
   end
   
   # function to transform a single column

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -170,16 +170,17 @@ reapply(transform::StatelessFeatureTransform, table, cache) =
 # ------------------
 
 function applyfeat(transform::ColwiseFeatureTransform, feat, prep)
-  # basic checks
-  for assertion in assertions(transform)
-    assertion(feat)
-  end
-
   # retrieve column names and values
-  cols   = Tables.columns(feat)
+  cols   = Tables.columns(feat) 
   names  = Tables.columnnames(cols)
-  snames = choose(transform.colspec, names)
+  snames = choose(transform.colspec, names) 
 
+  # basic checks 
+  for assertion in assertions(transform) 
+    # Perform the assertion on the selected columns of the input table
+    assertion(feat[:, snames]) 
+  end
+  
   # function to transform a single column
   function colfunc(n)
     x = Tables.getcolumn(cols, n)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -178,7 +178,6 @@ function applyfeat(transform::ColwiseFeatureTransform, feat, prep)
 
   # basic checks
   for assertion in assertions(transform)
-    # Perform the assertion on the selected columns of the input table
     assertion(sfeat)
   end
   

--- a/test/transforms/zscore.jl
+++ b/test/transforms/zscore.jl
@@ -86,4 +86,14 @@
   @test isapprox(σ[2], 1; atol=1e-6)
   tₒ = revert(T, n, c)
   @test Tables.matrix(t) ≈ Tables.matrix(tₒ)
+  
+  a=rand(Int,3)
+  b=rand(3)
+  t = Table(; a, b)
+  T = ZScore(:b)
+  n, c = apply(T, t)
+  @test isapprox(mean(n.b), 0; atol=1e-6)
+  @test isapprox(std(n.b), 1; atol=1e-6)
+  tₒ = revert(T, n, c)
+  @test Tables.matrix(t) ≈ Tables.matrix(tₒ)
 end

--- a/test/transforms/zscore.jl
+++ b/test/transforms/zscore.jl
@@ -87,8 +87,8 @@
   tₒ = revert(T, n, c)
   @test Tables.matrix(t) ≈ Tables.matrix(tₒ)
   
-  a=rand(Int,3)
-  b=rand(3)
+  a = rand(Int, 10)
+  b = rand(10)
   t = Table(; a, b)
   T = ZScore(:b)
   n, c = apply(T, t)


### PR DESCRIPTION
@juliohm  I fixed the Assertion Error and it is working fine now, then again was getting ```ERROR: MethodError: no method matching getindex(::NamedTuple{(:a, :b), Tuple{Vector{Int64}, Vector{Float64}}}, ::Colon, ::Vector{Symbol})``` for 
```jl
(a=rand(Int,3), b=rand(3)) |> ZScore(:b)
```
I guess the ZScore function expects the input data to be a tabular data structure, like DataFrame or a Table, but the input data in this case is a NamedTuple. Converting into dataframe, I am getting correct output:

```jl
julia> DataFrame((a=rand(Int,3), b=rand(3))) |> ZScore(:b)
3×2 DataFrame
 Row │ a                    b
     │ Int64                Float64
─────┼────────────────────────────────
   1 │ 4442619791281385888  -1.12529
   2 │ 7630774422502565167   0.786904
   3 │ 1978852580104395244   0.338386
```
