### PR TITLE
fix typos

### DIFF
--- a/docs/src/assets/dark.scss
+++ b/docs/src/assets/dark.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-// The customizable varibles can be found here:
+// The customizable variables can be found here:
 // https://github.com/JuliaDocs/Documenter.jl/tree/master/assets/html/scss
 // under documenter/_variables or documenter/_overrides. But some stuff are Bulma defaults
 // as well, so you may need to look them up too: https://bulma.io/documentation/customize/variables/
@@ -7,7 +7,7 @@
 
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
-// Thse define the template:
+// These define the template:
 $maincolor: rgb(78, 134, 151);   // main color of the org theme
 $secondcolor: rgb(197, 96, 255); // secondary color that serves as accents
                        // it is used as-is for links in light theme
@@ -136,7 +136,7 @@ html.theme--#{$themename} {
       background-color: darken-color($documenter-sidebar-background, 1);
       border-color: darken-color($documenter-sidebar-background, 2);
       margin-top: 1.0rem;
-      margin-bottom: 1.0rem; // adjust the margings between search and other elements
+      margin-bottom: 1.0rem; // adjust the margins between search and other elements
       &::placeholder {
         color: $mainwhite; // placeholder text color ("Search here...")
       }

--- a/docs/src/assets/light.scss
+++ b/docs/src/assets/light.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-// The customizable varibles can be found here:
+// The customizable variables can be found here:
 // https://github.com/JuliaDocs/Documenter.jl/tree/master/assets/html/scss
 // under documenter/_variables or documenter/_overrides. But some stuff are Bulma defaults
 // as well, so you may need to look them up too: https://bulma.io/documentation/customize/variables/
@@ -105,7 +105,7 @@ $input-focus-border-color: $mainwhite;
     background-color: darken-color($documenter-sidebar-background, 1);
     border-color: darken-color($documenter-sidebar-background, 2);
     margin-top: 1.0rem;
-    margin-bottom: 1.0rem; // adjust the margings between search and other elements
+    margin-bottom: 1.0rem; // adjust the margins between search and other elements
     &::placeholder {
       color: $mainwhite; // placeholder text color ("Search here...")
     }

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -1,6 +1,6 @@
 # Transforms
 
-Below is the list of tranforms that are are available in this package.
+Below is the list of transforms that are are available in this package.
 
 ## Select
 

--- a/src/transforms/coalesce.jl
+++ b/src/transforms/coalesce.jl
@@ -46,6 +46,6 @@ isrevertible(::Type{<:Coalesce}) = true
 
 colcache(::Coalesce, x) = findall(ismissing, x)
 
-colapply(tramsform::Coalesce, x, c) = coalesce.(x, tramsform.value)
+colapply(transform::Coalesce, x, c) = coalesce.(x, transform.value)
 
 colrevert(::Coalesce, y, c) = [i ∈ c ? missing : y[i] for i in 1:length(y)]

--- a/src/transforms/select.jl
+++ b/src/transforms/select.jl
@@ -129,7 +129,7 @@ Reject(spec) = Reject(colspec(spec))
 
 Reject(cols::T...) where {T<:Col} = Reject(colspec(cols))
 
-# argumet erros
+# argument errors
 Reject() = throw(ArgumentError("Cannot create a Reject object without arguments."))
 Reject(::AllSpec) = throw(ArgumentError("Cannot reject all columns."))
 

--- a/test/transforms/levels.jl
+++ b/test/transforms/levels.jl
@@ -101,7 +101,7 @@
   T = Levels("x" => ["n", "y", "m"], "y" => 1:4)
   @test_throws AssertionError apply(T, t)
 
-  # throws: non categorical collumn
+  # throws: non categorical column
   T = Levels(:a => [true, false], ordered=[:a])
   @test_throws AssertionError apply(T, t)
 

--- a/test/transforms/replace.jl
+++ b/test/transforms/replace.jl
@@ -61,7 +61,7 @@
   tₒ = revert(T, n, c)
   @test t == tₒ
 
-  # collumns with diferent types
+  # columns with different types
   a = [3, 2, 1, 4, 5, 3]
   b = [2.5, 4.5, 4.7, 2.5, 2.5, 5.3]
   c = [true, false, false, false, true, false]


### PR DESCRIPTION
docs/src/assets/dark.scss
docs/src/assets/light.scss
docs/src/transforms.md
src/transforms/coalesce.jl
src/transforms/select.jl
test/transforms/levels.jl
test/transforms/replace.jl

same docs style with typos as fixed in GeoStats `#272`, `#274`, and in Meshes `#468`