### PR TITLE
FIX: Use the `titlecase` function in (Upper) Camel Case

### DIFF
--- a/src/transforms/stdnames.jl
+++ b/src/transforms/stdnames.jl
@@ -86,7 +86,7 @@ end
 
 _uppersnake(name) = _isuppersnake(name) ? name : join(uppercase.(split(name, DELIMS)), '_')
 
-_uppercamel(name) = _isuppercamel(name) ? name : join(uppercasefirst.(split(name, DELIMS)))
+_uppercamel(name) = _isuppercamel(name) ? name : join(titlecase.(split(name, DELIMS)))
 
 _upperflat(name) = _isupperflat(name) ? name : replace(uppercase(name), DELIMS => "")
 
@@ -95,7 +95,7 @@ _snake(name) = _issnake(name) ? name : join(lowercase.(split(name, DELIMS)), '_'
 function _camel(name)
   _iscamel(name) && return name
   first, others... = split(name, DELIMS)
-  join([lowercase(first); uppercasefirst.(others)])
+  join([lowercase(first); titlecase.(others)])
 end
 
 _flat(name) = _isflat(name) ? name : replace(lowercase(name), DELIMS => "")

--- a/test/transforms/stdnames.jl
+++ b/test/transforms/stdnames.jl
@@ -38,6 +38,21 @@
   tₒ = revert(T, n, c)
   @test t == tₒ
 
+  # titlecase
+  names = Symbol.(["_apPLe trEe_", " baNaNA-fRuIt ", "-peAR\tsEEd-"])
+  t = Table(; zip(names, columns)...)
+  T = StdNames(:uppercamel)
+  n, c = apply(T, t)
+  @test Tables.schema(n).names == (:AppleTree, :BananaFruit, :PearSeed)
+  tₒ = revert(T, n, c)
+  @test t == tₒ
+
+  T = StdNames(:camel)
+  n, c = apply(T, t)
+  @test Tables.schema(n).names == (:appleTree, :bananaFruit, :pearSeed)
+  tₒ = revert(T, n, c)
+  @test t == tₒ
+
   # internal functions
   names = ["apple banana", "apple\tbanana", "apple_banana", "apple-banana", "apple_Banana"]
   for name in names


### PR DESCRIPTION
Bug description:
The `uppercasefirst` function is not the corect function for Camel Case, the corect is the `titlecase` function:
```
julia> uppercasefirst("aBc")
"ABc"

julia> titlecase("aBc")
"Abc"
```