### PR TITLE
Replace the `assert` macro with the new `_assert` utility function

### DIFF
--- a/src/assertions.jl
+++ b/src/assertions.jl
@@ -22,6 +22,12 @@ function (assertion::SciTypeAssertion{T})(table) where {T}
 
   for nm in snames
     x = Tables.getcolumn(cols, nm)
-    @assert elscitype(x) <: T "the elements of the column '$nm' are not of scientific type $T"
+    _assert(elscitype(x) <: T, "the elements of the column '$nm' are not of scientific type $T")
   end
 end
+
+#-------
+# UTILS
+#-------
+
+_assert(cond, msg) = cond || throw(AssertionError(msg))

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -11,7 +11,7 @@ struct EmpiricalDistribution{T<:Real} <: ContinuousUnivariateDistribution
   values::Vector{T}
 
   function EmpiricalDistribution{T}(values) where {T<:Real}
-    @assert !isempty(values) "values must be provided"
+    _assert(!isempty(values), "values must be provided")
     new(sort(values))
   end
 end

--- a/src/tableselection.jl
+++ b/src/tableselection.jl
@@ -12,7 +12,7 @@ struct TableSelection{T,C}
 
   function TableSelection(table::T, names, onames) where {T}
     cols = Tables.columns(table)
-    @assert onames ⊆ Tables.columnnames(cols)
+    _assert(onames ⊆ Tables.columnnames(cols), "all selected columns must exist in the table")
     ncols = length(names)
     mapnames = Dict(zip(names, onames))
     new{T,typeof(cols)}(table, cols, ncols, names, onames, mapnames)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -139,7 +139,7 @@ function apply(transform::FeatureTransform, table)
 end
 
 function revert(transform::FeatureTransform, newtable, cache)
-  @assert isrevertible(transform) "Transform is not revertible"
+  _assert(isrevertible(transform), "Transform is not revertible")
 
   newfeat, newmeta = divide(newtable)
   fcache, mcache = cache
@@ -242,7 +242,7 @@ function reapplyfeat(transform::ColwiseFeatureTransform, feat, fcache)
   caches, snames = fcache
 
   # check that cache is valid
-  @assert length(names) == length(caches) "invalid caches for feat"
+  _assert(length(names) == length(caches), "invalid caches for feat")
 
   # function to transform a single column
   function colfunc(i)

--- a/src/transforms/dropextrema.jl
+++ b/src/transforms/dropextrema.jl
@@ -22,7 +22,7 @@ struct DropExtrema{S<:SingleColumnSelector,T} <: StatelessFeatureTransform
   high::T
 
   function DropExtrema(selector::S, low::T, high::T) where {S<:SingleColumnSelector,T}
-    @assert 0 ≤ low ≤ high ≤ 1 "invalid quantiles"
+    _assert(0 ≤ low ≤ high ≤ 1, "invalid quantiles")
     new{S,T}(selector, low, high)
   end
 end

--- a/src/transforms/eigenanalysis.jl
+++ b/src/transforms/eigenanalysis.jl
@@ -44,8 +44,8 @@ struct EigenAnalysis <: FeatureTransform
   pratio::Float64
 
   function EigenAnalysis(proj, maxdim, pratio)
-    @assert proj ∈ (:V, :VD, :VDV) "Invalid projection."
-    @assert 0 ≤ pratio ≤ 1 "Invalid pratio."
+    _assert(proj ∈ (:V, :VD, :VDV), "invalid projection")
+    _assert(0 ≤ pratio ≤ 1, "invalid pratio")
     new(proj, maxdim, pratio)
   end
 end

--- a/src/transforms/functional.jl
+++ b/src/transforms/functional.jl
@@ -78,8 +78,6 @@ function applyfeat(transform::Functional, feat, prep)
 end
 
 function revertfeat(transform::Functional, newfeat, fcache)
-  @assert isrevertible(transform) "TableTransform is not revertible."
-
   cols = Tables.columns(newfeat)
   names = Tables.columnnames(cols)
 

--- a/src/transforms/logratio.jl
+++ b/src/transforms/logratio.jl
@@ -28,7 +28,7 @@ function applyfeat(transform::LogRatio, feat, prep)
 
   # reference variable
   rvar = refvar(transform, names)
-  @assert rvar ∈ names "invalid reference variable"
+  _assert(rvar ∈ names, "invalid reference variable")
   rind = findfirst(==(rvar), names)
 
   # permute columns if necessary

--- a/src/transforms/parallel.jl
+++ b/src/transforms/parallel.jl
@@ -54,7 +54,7 @@ function apply(p::ParallelTableTransform, table)
   metas = last.(splits)
 
   # check the number of rows of generated tables
-  @assert allequal(_nrows(f) for f in feats) "parallel branches must produce the same number of rows"
+  _assert(allequal(_nrows(f) for f in feats), "parallel branches must produce the same number of rows")
 
   # table with concatenated features
   newfeat = tablehcat(feats)
@@ -90,7 +90,7 @@ function revert(p::ParallelTableTransform, newtable, cache)
   caches = cache[1]
   rinfo = cache[2]
 
-  @assert !isnothing(rinfo) "transform is not revertible"
+  _assert(!isnothing(rinfo), "transform is not revertible")
 
   # features and metadata
   newfeat, newmeta = divide(newtable)
@@ -132,7 +132,7 @@ function reapply(p::ParallelTableTransform, table, cache)
   metas = last.(splits)
 
   # check the number of rows of generated tables
-  @assert allequal(_nrows(f) for f in feats) "parallel branches must produce the same number of rows"
+  _assert(allequal(_nrows(f) for f in feats), "parallel branches must produce the same number of rows")
 
   # table with concatenated features
   newfeat = tablehcat(feats)

--- a/src/transforms/remainder.jl
+++ b/src/transforms/remainder.jl
@@ -38,7 +38,7 @@ function applyfeat(transform::Remainder, feat, prep)
   else
     t = convert(eltype(X), transform.total)
     # make sure that the total is valid
-    @assert all(≤(t), S) "the sum for each row must be less than total"
+    _assert(all(≤(t), S), "the sum for each row must be less than total")
     t
   end
 

--- a/src/transforms/rename.jl
+++ b/src/transforms/rename.jl
@@ -20,7 +20,7 @@ struct Rename{S<:ColumnSelector} <: StatelessFeatureTransform
   selector::S
   newnames::Vector{Symbol}
   function Rename(selector::S, newnames) where {S<:ColumnSelector}
-    @assert allunique(newnames) "new names must be unique"
+    _assert(allunique(newnames), "new names must be unique")
     new{S}(selector, newnames)
   end
 end
@@ -36,7 +36,7 @@ function applyfeat(transform::Rename, feat, prep)
   cols = Tables.columns(feat)
   names = Tables.columnnames(cols)
   snames = transform.selector(names)
-  @assert transform.newnames ⊈ setdiff(names, snames) "duplicate names"
+  _assert(transform.newnames ⊈ setdiff(names, snames), "duplicate names")
 
   mapnames = Dict(zip(snames, transform.newnames))
   newnames = [get(mapnames, nm, nm) for nm in names]

--- a/src/transforms/scale.jl
+++ b/src/transforms/scale.jl
@@ -37,7 +37,7 @@ struct Scale{S<:ColumnSelector,T} <: ColwiseFeatureTransform
   high::T
 
   function Scale(selector::S, low::T, high::T) where {S<:ColumnSelector,T}
-    @assert 0 ≤ low ≤ high ≤ 1 "invalid quantiles"
+    _assert(0 ≤ low ≤ high ≤ 1, "invalid quantiles")
     new{S,T}(selector, low, high)
   end
 end


### PR DESCRIPTION
Motivation: `@assert` docstring:
```
help?> @assert
  @assert cond [text]

  Throw an AssertionError if cond is false. Preferred syntax for writing
  assertions. Message text is optionally displayed upon assertion failure.

  │ Warning
  │
  │  An assert might be disabled at various optimization levels. Assert
  │  should therefore only be used as a debugging tool and not used for
  │  authentication verification (e.g., verifying passwords), nor should
  │  side effects needed for the function to work correctly be used
  │  inside of asserts.
```
