### PR TITLE
Add support for vector of pairs in `Rename` transform

### DIFF
--- a/src/transforms/rename.jl
+++ b/src/transforms/rename.jl
@@ -4,6 +4,7 @@
 
 """
     Rename(:col₁ => :newcol₁, :col₂ => :newcol₂, ..., :colₙ => :newcolₙ)
+    Rename([:col₁ => :newcol₁, :col₂ => :newcol₂, ..., :colₙ => :newcolₙ])
 
 The transform that renames `col₁`, `col₂`, ..., `colₙ`
 to `newcol₁`, `newcol₂`, ..., `newcolₙ`.
@@ -14,6 +15,9 @@ to `newcol₁`, `newcol₂`, ..., `newcolₙ`.
 Rename(1 => :x, 3 => :y)
 Rename(:a => :x, :c => :y)
 Rename("a" => "x", "c" => "y")
+Rename([1 => "x", 3 => "y"])
+Rename([:a => "x", :c => "y"])
+Rename(["a", "c"] .=> [:x, :y])
 ```
 """
 struct Rename{S<:ColumnSelector} <: StatelessFeatureTransform
@@ -29,6 +33,11 @@ Rename(pairs::Pair{C,Symbol}...) where {C<:Column} = Rename(selector(first.(pair
 
 Rename(pairs::Pair{C,S}...) where {C<:Column,S<:AbstractString} =
   Rename(selector(first.(pairs)), collect(Symbol.(last.(pairs))))
+
+Rename(pairs::AbstractVector{Pair{C,Symbol}}) where {C<:Column} = Rename(selector(first.(pairs)), last.(pairs))
+
+Rename(pairs::AbstractVector{Pair{C,S}}) where {C<:Column,S<:AbstractString} =
+  Rename(selector(first.(pairs)), Symbol.(last.(pairs)))
 
 isrevertible(::Type{<:Rename}) = true
 

--- a/test/transforms/rename.jl
+++ b/test/transforms/rename.jl
@@ -109,6 +109,43 @@
   n2 = reapply(T, t, c1)
   @test n1 == n2
 
+  # vector of pairs
+  T = Rename([1 => :x, 3 => :y])
+  n, c = apply(T, t)
+  @test Tables.columnnames(n) == (:x, :b, :y, :d)
+  tₒ = revert(T, n, c)
+  @test t == tₒ
+
+  T = Rename([2, 4] .=> ["x", "y"])
+  n, c = apply(T, t)
+  @test Tables.columnnames(n) == (:a, :x, :c, :y)
+  tₒ = revert(T, n, c)
+  @test t == tₒ
+
+  T = Rename([:a => :x, :c => :y])
+  n, c = apply(T, t)
+  @test Tables.columnnames(n) == (:x, :b, :y, :d)
+  tₒ = revert(T, n, c)
+  @test t == tₒ
+
+  T = Rename([:b, :d] .=> ["x", "y"])
+  n, c = apply(T, t)
+  @test Tables.columnnames(n) == (:a, :x, :c, :y)
+  tₒ = revert(T, n, c)
+  @test t == tₒ
+
+  T = Rename(["a" => :x, "c" => :y])
+  n, c = apply(T, t)
+  @test Tables.columnnames(n) == (:x, :b, :y, :d)
+  tₒ = revert(T, n, c)
+  @test t == tₒ
+
+  T = Rename(["b", "d"] .=> ["x", "y"])
+  n, c = apply(T, t)
+  @test Tables.columnnames(n) == (:a, :x, :c, :y)
+  tₒ = revert(T, n, c)
+  @test t == tₒ
+
   # throws
   @test_throws AssertionError Rename(:a => :x, :b => :x)
   @test_throws AssertionError apply(Rename(:a => :c, :b => :d), t)


### PR DESCRIPTION
closes #260 