### PR TITLE
Add more arg types in Map transform

### DIFF
--- a/test/shows.jl
+++ b/test/shows.jl
@@ -279,14 +279,14 @@
     # compact mode
     iostr = sprint(show, T)
     @test iostr ==
-          "Map(selectors: ColumnSelector[:a, [:a, :b]], funs: Function[sin, $(nameof(fun))], targets: Union{Nothing, Symbol}[nothing, :c])"
+          "Map(selectors: ColumnSelector[:a, [:a, :b]], funs: Union{Function, Type}[sin, #13], targets: Union{Nothing, Symbol}[nothing, :c])"
 
     # full mode
     iostr = sprint(show, MIME("text/plain"), T)
     @test iostr == """
     Map transform
     ├─ selectors: ColumnSelectors.ColumnSelector[:a, [:a, :b]]
-    ├─ funs: Function[sin, $(typeof(fun))()]
+    ├─ funs: Union{Function, Type}[sin, $(typeof(fun))()]
     └─ targets: Union{Nothing, Symbol}[nothing, :c]"""
   end
 

--- a/test/transforms/map.jl
+++ b/test/transforms/map.jl
@@ -96,6 +96,36 @@
   @test Tables.schema(n).names == (:fix2_hypot_a,)
   @test n.fix2_hypot_a == f.(t.a)
 
+  # function and target
+  f = (a, b, c, d) -> a + b + c + d
+  T = Map(f => "target")
+  n, c = apply(T, t)
+  @test Tables.schema(n).names == (:target,)
+  @test n.target == f.(t.a, t.b, t.c, t.d)
+
+  # function alone
+  f = (a, b, c, d) -> a + b + c + d
+  fname = replace(string(f), "#" => "f")
+  colname = Symbol(fname, :_a, :_b, :_c, :_d)
+  T = Map(f)
+  n, c = apply(T, t)
+  @test Tables.schema(n).names == (colname,)
+  @test Tables.getcolumn(n, colname) == f.(t.a, t.b, t.c, t.d)
+
+  # type and target
+  struct Foo a; b; c; d end
+  T = Map(Foo => "target")
+  n, c = apply(T, t)
+  @test Tables.schema(n).names == (:target,)
+  @test n.target == Foo.(t.a, t.b, t.c, t.d)
+
+  # type alone
+  struct Bar a; b; c; d end
+  T = Map(Bar)
+  n, c = apply(T, t)
+  @test Tables.schema(n).names == (:Bar_a_b_c_d,)
+  @test n.Bar_a_b_c_d == Bar.(t.a, t.b, t.c, t.d)
+
   # error: cannot create Map transform without arguments
   @test_throws ArgumentError Map()
 end


### PR DESCRIPTION
Allow types in `Map` transform to enable convenient pipelines like

```julia
using TableTransforms
using Colors

ColorView(color=RGB; low=0.02, high=0.98) = LowHigh(; low, high) → Map(color)
```