### PR TITLE
Add Doc Cleanup action & Show only latest docs

### DIFF
--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -1,0 +1,24 @@
+name: Doc Cleanup
+on:
+  # runs on the 1st day of every month at 03:00 UTC
+  schedule:
+    - cron: '0 3 1 * *'
+  workflow_dispatch:
+jobs:
+  doc-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+      - name: Delete old docs
+        run: |
+            keep=$(readlink stable)
+            git config user.name "Documenter.jl"
+            git config user.email "documenter@juliadocs.github.io"
+            git rm -rf v[0-9]*.[0-9]* && git checkout HEAD -- $keep
+            if git commit -m "keep latest docs only" ; then
+              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin gh-pages-new:gh-pages
+            fi

--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -21,7 +21,10 @@ jobs:
             git config user.email "documenter@juliadocs.github.io"
             git rm -rf --ignore-unmatch v[0-9]*.[0-9]*
             git checkout HEAD -- "$keep"
-            if git commit -m "keep latest docs only" ; then
+            if git diff --cached --quiet; then
+              echo "No old docs to delete."
+            else
+              git commit -m "keep latest docs only"
               git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
               git push --force origin gh-pages-new:gh-pages
             fi

--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 3 1 * *'
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   doc-cleanup:
     runs-on: ubuntu-latest
@@ -14,10 +16,11 @@ jobs:
           ref: gh-pages
       - name: Delete old docs
         run: |
-            keep=$(readlink stable)
+            keep="$(readlink stable)"
             git config user.name "Documenter.jl"
             git config user.email "documenter@juliadocs.github.io"
-            git rm -rf v[0-9]*.[0-9]* && git checkout HEAD -- $keep
+            git rm -rf --ignore-unmatch v[0-9]*.[0-9]*
+            git checkout HEAD -- "$keep"
             if git commit -m "keep latest docs only" ; then
               git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
               git push --force origin gh-pages-new:gh-pages

--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -22,9 +22,9 @@ jobs:
             git rm -rf --ignore-unmatch v[0-9]*.[0-9]*
             git checkout HEAD -- "$keep"
             if git diff --cached --quiet; then
-              echo "No old docs to delete."
+              echo "No old docs to delete"
             else
-              git commit -m "keep latest docs only"
+              git commit -m "Keep latest docs only"
               git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
               git push --force origin gh-pages-new:gh-pages
             fi

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,4 +21,9 @@ makedocs(;
   ]
 )
 
-deploydocs(; repo="github.com/JuliaML/TableTransforms.jl", devbranch="master", push_preview=true)
+deploydocs(;
+  repo="github.com/JuliaML/TableTransforms.jl",
+  versions=["stable" => "v^", "dev" => "dev"],
+  devbranch="master",
+  push_preview=true
+)


### PR DESCRIPTION
This PR adds the Doc Cleanup action to clean up old documentation versions, just as is done in [MeshesDocs](https://github.com/JuliaGeometry/MeshesDocs/blob/main/.github/workflows/DocCleanup.yml) and [GeoStatsDocs](https://github.com/JuliaEarth/GeoStatsDocs/blob/main/.github/workflows/DocCleanup.yml).

It also modifies make.jl to show only the latest version of the documentation.

The action will run on the 1st of the month at 3:00 UTC, as this is a time of lower computational load for GitHub's servers.
The action can also be triggered manually, when necessary.

Fix #322 